### PR TITLE
Improves FileGroup handling in Developer Mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,32 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+
+### Added
+
+**FileGroup Handling in Developer Mode**
+- **`autoRemap` Strategy** (new default): Automatically imports FileGroups with auto-detected paths
+  - Detects SQL Server's default data directory using `SERVERPROPERTY('InstanceDefaultDataPath')`
+  - Generates unique .ndf file paths automatically (no configuration required)
+  - Preserves FileGroup structure for accurate development/testing
+  - Works cross-platform (Windows/Linux SQL Server)
+- **`removeToPrimary` Strategy** (optional): Skips FileGroups and remaps all references to PRIMARY
+  - Simplifies local setup when FileGroup structure isn't needed
+  - Uses regex transformations to rewrite table/index/partition scheme DDL
+- New `fileGroupStrategy` configuration option in `developerMode` settings (`autoRemap` or `removeToPrimary`)
+- New `Get-DefaultDataPath` function in Import-SqlServerSchema.ps1
+- Enhanced test database with partitioned tables to validate partition scheme handling
+
+### Changed
+- **Breaking**: Developer Mode now imports FileGroups by default (using `autoRemap`)
+  - Previous behavior (skip FileGroups) available via `fileGroupStrategy: removeToPrimary`
+- Updated test validation to verify FileGroup placement
+- Updated README.md with FileGroup strategy documentation
+- Updated export-import-config.example.yml with `fileGroupStrategy` examples
+
+---
+
 ## [1.3.0] - 2026-01-12
 
 ### Changed

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -1530,7 +1530,7 @@ try {
                         $fileName = $matches[1].Trim()
                         
                         # SECURITY: Sanitize filename
-                        if ($fileName -notmatch '^[a-zA-Z0-9_.-]+$') {
+                        if ($fileName -notmatch '^[a-zA-Z0-9_.\\-]+$') {
                             Write-Warning "[WARNING] FileGroup file name '$fileName' contains unsafe characters. Skipping."
                             continue
                         }
@@ -1614,7 +1614,7 @@ try {
                         
                         # SECURITY: Sanitize filename to prevent SQL injection via SQLCMD variable substitution
                         # Only allow alphanumeric, dash, underscore, and period for safe filesystem names
-                        if ($originalFileName -notmatch '^[a-zA-Z0-9_.-]+$') {
+                        if ($originalFileName -notmatch '^[a-zA-Z0-9_.\\-]+$') {
                             Write-Warning "[WARNING] FileGroup file name '$originalFileName' contains unsafe characters. Skipping."
                             continue
                         }

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -783,10 +783,14 @@ function Invoke-SqlScript {
             #    Pattern: closing paren followed by ON [anything-except-PRIMARY]
             $sql = $sql -replace '\)\s*ON\s*\[(?!PRIMARY\])[^\]]+\]', ') ON [PRIMARY]'
             
-            # 2. Partition Schemes: Replace TO ([FG1], [FG2], ...) with ALL TO ([PRIMARY])
+            # 2. Partition Schemes (TO ...): Replace TO ([FG1], [FG2], ...) with ALL TO ([PRIMARY])
             #    Pattern: TO ( followed by list of filegroups in brackets
             #    Guard against already-transformed "ALL TO ([PRIMARY])" and PRIMARY-only "TO ([PRIMARY])"
             $sql = $sql -replace '(?<!ALL\s)TO\s*\(\s*(?!\[PRIMARY\]\s*\))\[[^\]]+\](?:\s*,\s*\[[^\]]+\])*\s*\)', 'ALL TO ([PRIMARY])'
+            
+            # 3. Partition Schemes (ALL TO ...): Replace ALL TO ([NonPrimary]) with ALL TO ([PRIMARY])
+            #    Pattern: ALL TO ([FileGroup]) where FileGroup is not PRIMARY
+            $sql = $sql -replace 'ALL\s+TO\s*\(\s*\[(?!PRIMARY\])[^\]]+\]\s*\)', 'ALL TO ([PRIMARY])'
         }
         
         # Replace ALTER DATABASE CURRENT with actual database name

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -1559,16 +1559,13 @@ try {
                 
                 # Parse FileGroup file to extract names
                 $currentFG = $null
-                $fileIndex = @{}  # Track file count per FileGroup for uniqueness
                 
                 foreach ($line in (Get-Content $fileGroupScript)) {
                     if ($line -match '-- FileGroup: (.+)') {
                         $currentFG = $matches[1]
-                        $fileIndex[$currentFG] = 0
                     }
                     elseif ($line -match '-- File: (.+)' -and $currentFG) {
                         $originalFileName = $matches[1]
-                        $fileIndex[$currentFG]++
                         
                         # Build unique filename: DatabaseName_FileGroupName_OriginalName.ndf
                         $uniqueFileName = "${Database}_${currentFG}_${originalFileName}"

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -785,7 +785,8 @@ function Invoke-SqlScript {
             
             # 2. Partition Schemes: Replace TO ([FG1], [FG2], ...) with ALL TO ([PRIMARY])
             #    Pattern: TO ( followed by list of filegroups in brackets
-            $sql = $sql -replace 'TO\s*\(\s*\[[^\]]+\](?:\s*,\s*\[[^\]]+\])*\s*\)', 'ALL TO ([PRIMARY])'
+            #    Guard against already-transformed "ALL TO ([PRIMARY])" and PRIMARY-only "TO ([PRIMARY])"
+            $sql = $sql -replace '(?<!ALL\s)TO\s*\(\s*(?!\[PRIMARY\]\s*\))\[[^\]]+\](?:\s*,\s*\[[^\]]+\])*\s*\)', 'ALL TO ([PRIMARY])'
         }
         
         # Replace ALTER DATABASE CURRENT with actual database name

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -1503,7 +1503,7 @@ try {
         
         if ($modeConfig -and $modeConfig.fileGroupPathMapping) {
             # SECURITY: Sanitize database name for use in filesystem paths
-            $sanitizedDbName = $Database -replace '[^a-zA-Z0-9_\-]', '_'
+            $sanitizedDbName = $Database -replace '[^a-zA-Z0-9_-]', '_'
             
             # First pass: read FileGroups SQL to extract file names
             $fileGroupScript = Join-Path $SourcePath '00_FileGroups' '001_FileGroups.sql'
@@ -1517,7 +1517,7 @@ try {
                         $fgName = $matches[1].Trim()
                         
                         # SECURITY: Sanitize FileGroup name
-                        if ($fgName -notmatch '^[a-zA-Z0-9_\-]+$') {
+                        if ($fgName -notmatch '^[a-zA-Z0-9_-]+$') {
                             Write-Warning "[WARNING] FileGroup name '$fgName' contains unsafe characters. Skipping."
                             $currentFG = $null
                             continue
@@ -1530,7 +1530,7 @@ try {
                         $fileName = $matches[1].Trim()
                         
                         # SECURITY: Sanitize filename
-                        if ($fileName -notmatch '^[a-zA-Z0-9_\-\.]+$') {
+                        if ($fileName -notmatch '^[a-zA-Z0-9_.-]+$') {
                             Write-Warning "[WARNING] FileGroup file name '$fileName' contains unsafe characters. Skipping."
                             continue
                         }
@@ -1585,7 +1585,7 @@ try {
                 Write-Output "[INFO] Auto-remapping FileGroup paths to: $defaultDataPath"
                 
                 # SECURITY: Sanitize database name for use in filesystem paths
-                $sanitizedDbName = $Database -replace '[^a-zA-Z0-9_\-]', '_'
+                $sanitizedDbName = $Database -replace '[^a-zA-Z0-9_-]', '_'
                 
                 # Parse FileGroup file to extract names
                 $currentFG = $null
@@ -1600,7 +1600,7 @@ try {
                         # 1) SQLCMD variable names must be valid PowerShell variable names
                         # 2) Filesystem paths should avoid special characters for cross-platform safety
                         # 3) Prevents potential injection via special character sequences
-                        if ($fgName -notmatch '^[a-zA-Z0-9_\-]+$') {
+                        if ($fgName -notmatch '^[a-zA-Z0-9_-]+$') {
                             Write-Warning "[WARNING] FileGroup name '$fgName' contains unsafe characters. Skipping."
                             $currentFG = $null
                             continue
@@ -1614,7 +1614,7 @@ try {
                         
                         # SECURITY: Sanitize filename to prevent SQL injection via SQLCMD variable substitution
                         # Only allow alphanumeric, dash, underscore, and period for safe filesystem names
-                        if ($originalFileName -notmatch '^[a-zA-Z0-9_\-\.]+$') {
+                        if ($originalFileName -notmatch '^[a-zA-Z0-9_.-]+$') {
                             Write-Warning "[WARNING] FileGroup file name '$originalFileName' contains unsafe characters. Skipping."
                             continue
                         }

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -1530,7 +1530,7 @@ try {
                         $fileName = $matches[1].Trim()
                         
                         # SECURITY: Sanitize filename
-                        if ($fileName -notmatch '^[a-zA-Z0-9_.\\-]+$') {
+                        if ($fileName -notmatch '^[a-zA-Z0-9_.-]+$') {
                             Write-Warning "[WARNING] FileGroup file name '$fileName' contains unsafe characters. Skipping."
                             continue
                         }
@@ -1614,7 +1614,7 @@ try {
                         
                         # SECURITY: Sanitize filename to prevent SQL injection via SQLCMD variable substitution
                         # Only allow alphanumeric, dash, underscore, and period for safe filesystem names
-                        if ($originalFileName -notmatch '^[a-zA-Z0-9_.\\-]+$') {
+                        if ($originalFileName -notmatch '^[a-zA-Z0-9_.-]+$') {
                             Write-Warning "[WARNING] FileGroup file name '$originalFileName' contains unsafe characters. Skipping."
                             continue
                         }

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -1588,7 +1588,9 @@ try {
             }
         } else {
             Write-Warning "[WARNING] Could not auto-detect default data path"
-            Write-Warning "  FileGroup import may fail. Consider providing fileGroupPathMapping in config."
+            Write-Warning "  Falling back to FileGroup strategy: removeToPrimary (all FileGroups will map to PRIMARY)."
+            $sqlCmdVars['__RemapFileGroupsToPrimary__'] = $true
+            Write-Warning "  To customize FileGroup paths, provide fileGroupPathMapping in config or define SQLCMD variables explicitly."
         }
     }
     

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -1502,6 +1502,9 @@ try {
         }
         
         if ($modeConfig -and $modeConfig.fileGroupPathMapping) {
+            # SECURITY: Sanitize database name for use in filesystem paths
+            $sanitizedDbName = $Database -replace '[^a-zA-Z0-9_\-]', '_'
+            
             # First pass: read FileGroups SQL to extract file names
             $fileGroupScript = Join-Path $SourcePath '00_FileGroups' '001_FileGroups.sql'
             $fileGroupFiles = @{}  # Map: FileGroup -> [list of file names]
@@ -1511,11 +1514,28 @@ try {
                 $currentFG = $null
                 foreach ($line in (Get-Content $fileGroupScript)) {
                     if ($line -match '-- FileGroup: (.+)') {
-                        $currentFG = $matches[1]
+                        $fgName = $matches[1].Trim()
+                        
+                        # SECURITY: Sanitize FileGroup name
+                        if ($fgName -notmatch '^[a-zA-Z0-9_\-]+$') {
+                            Write-Warning "[WARNING] FileGroup name '$fgName' contains unsafe characters. Skipping."
+                            $currentFG = $null
+                            continue
+                        }
+                        
+                        $currentFG = $fgName
                         $fileGroupFiles[$currentFG] = @()
                     }
                     elseif ($line -match '-- File: (.+)' -and $currentFG) {
-                        $fileGroupFiles[$currentFG] += $matches[1]
+                        $fileName = $matches[1].Trim()
+                        
+                        # SECURITY: Sanitize filename
+                        if ($fileName -notmatch '^[a-zA-Z0-9_\-\.]+$') {
+                            Write-Warning "[WARNING] FileGroup file name '$fileName' contains unsafe characters. Skipping."
+                            continue
+                        }
+                        
+                        $fileGroupFiles[$currentFG] += $fileName
                     }
                 }
             }
@@ -1534,8 +1554,8 @@ try {
                 if ($fileGroupFiles.ContainsKey($fg)) {
                     foreach ($fileName in $fileGroupFiles[$fg]) {
                         $fileVarName = "${fg}_PATH_FILE"
-                        # Use database name + original file name for uniqueness
-                        $uniqueFileName = "${Database}_${fileName}"
+                        # Use sanitized database name + original file name for uniqueness
+                        $uniqueFileName = "${sanitizedDbName}_${fileName}"
                         $fullPath = "${basePath}${pathSeparator}${uniqueFileName}.ndf"
                         $sqlCmdVars[$fileVarName] = $fullPath
                         Write-Verbose "SQLCMD Variable: `$($fileVarName) = $fullPath"
@@ -1557,18 +1577,46 @@ try {
             if (Test-Path $fileGroupScript) {
                 Write-Output "[INFO] Auto-remapping FileGroup paths to: $defaultDataPath"
                 
+                # SECURITY: Sanitize database name for use in filesystem paths
+                $sanitizedDbName = $Database -replace '[^a-zA-Z0-9_\-]', '_'
+                
                 # Parse FileGroup file to extract names
                 $currentFG = $null
+                $fileIndex = @{}  # Track file count per FileGroup for uniqueness
                 
                 foreach ($line in (Get-Content $fileGroupScript)) {
                     if ($line -match '-- FileGroup: (.+)') {
-                        $currentFG = $matches[1]
+                        $fgName = $matches[1].Trim()
+                        
+                        # SECURITY: Sanitize FileGroup name to prevent injection attacks
+                        # SQL Server identifiers can contain letters, digits, @, #, _, $, but we use stricter rules
+                        # for filesystem safety and SQLCMD variable names
+                        if ($fgName -notmatch '^[a-zA-Z0-9_\-]+$') {
+                            Write-Warning "[WARNING] FileGroup name '$fgName' contains unsafe characters. Skipping."
+                            $currentFG = $null
+                            continue
+                        }
+                        
+                        $currentFG = $fgName
+                        $fileIndex[$currentFG] = 0
                     }
                     elseif ($line -match '-- File: (.+)' -and $currentFG) {
-                        $originalFileName = $matches[1]
+                        $originalFileName = $matches[1].Trim()
+                        
+                        # SECURITY: Sanitize filename to prevent SQL injection via SQLCMD variable substitution
+                        # Only allow alphanumeric, dash, underscore, and period for safe filesystem names
+                        if ($originalFileName -notmatch '^[a-zA-Z0-9_\-\.]+$') {
+                            Write-Warning "[WARNING] FileGroup file name '$originalFileName' contains unsafe characters. Skipping."
+                            continue
+                        }
+                        
+                        # Additional defense-in-depth: escape single quotes for SQL string literals
+                        $sanitizedFileName = $originalFileName -replace "'", "''"
+                        
+                        $fileIndex[$currentFG]++
                         
                         # Build unique filename: DatabaseName_FileGroupName_OriginalName.ndf
-                        $uniqueFileName = "${Database}_${currentFG}_${originalFileName}"
+                        $uniqueFileName = "${sanitizedDbName}_${currentFG}_${sanitizedFileName}"
                         $fullPath = "${defaultDataPath}${pathSeparator}${uniqueFileName}.ndf"
                         
                         # Set the SQLCMD variable

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -1574,7 +1574,13 @@ try {
                         $fullPath = "${defaultDataPath}${pathSeparator}${uniqueFileName}.ndf"
                         
                         # Set the SQLCMD variable
-                        $varName = "${currentFG}_PATH_FILE"
+                        # Preserve original behavior for first file, add numeric suffix for additional files
+                        $index = $fileIndex[$currentFG]
+                        if ($index -le 1) {
+                            $varName = "${currentFG}_PATH_FILE"
+                        } else {
+                            $varName = "{0}_PATH_FILE{1}" -f $currentFG, $index
+                        }
                         $sqlCmdVars[$varName] = $fullPath
                         Write-Verbose "  Auto-mapped: `$($varName) = $fullPath"
                     }

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -781,7 +781,7 @@ function Invoke-SqlScript {
             
             # 1. Tables/Indexes: Replace ) ON [FileGroup] with ) ON [PRIMARY]
             #    Pattern: closing paren followed by ON [anything-except-PRIMARY]
-            $sql = $sql -replace '\)\s*ON\s*\[(?!PRIMARY\])([^\]]+)\]', ') ON [PRIMARY]'
+            $sql = $sql -replace '\)\s*ON\s*\[(?!PRIMARY\])[^\]]+\]', ') ON [PRIMARY]'
             
             # 2. Partition Schemes: Replace TO ([FG1], [FG2], ...) with ALL TO ([PRIMARY])
             #    Pattern: TO ( followed by list of filegroups in brackets

--- a/export-import-config.example.yml
+++ b/export-import-config.example.yml
@@ -107,8 +107,17 @@ import:
   # DEVELOPER MODE SETTINGS (Local Development)
   # ─────────────────────────────────────────────────────────────
   developerMode:
-    # Skip FileGroups and remap all objects to PRIMARY
-    # Reason: Simplifies local setup, no need for multiple data files
+    # FileGroup handling strategy:
+    # - 'autoRemap': (default) Import FileGroups, auto-detect data path
+    #   Uses SERVERPROPERTY('InstanceDefaultDataPath') to place .ndf files
+    #   Preserves FileGroup structure while adapting to local environment
+    # - 'removeToPrimary': Skip FileGroups, remap all references to PRIMARY
+    #   Simplifies setup by using only PRIMARY FileGroup
+    #   All tables/indexes/partitions moved to PRIMARY
+    fileGroupStrategy: autoRemap
+    
+    # Legacy setting (ignored if fileGroupStrategy is set)
+    # Kept for backward compatibility
     includeFileGroups: false
     
     # Skip database scoped configurations (use server defaults)

--- a/export-import-config.schema.json
+++ b/export-import-config.schema.json
@@ -139,9 +139,15 @@
       "type": "object",
       "description": "Import mode settings",
       "properties": {
+        "fileGroupStrategy": {
+          "type": "string",
+          "enum": ["autoRemap", "removeToPrimary"],
+          "description": "FileGroup handling strategy (autoRemap = import with auto-detected paths, removeToPrimary = skip FileGroups and remap to PRIMARY)",
+          "default": "autoRemap"
+        },
         "includeFileGroups": {
           "type": "boolean",
-          "description": "Import FileGroup definitions and create files",
+          "description": "Import FileGroup definitions and create files (legacy, ignored if fileGroupStrategy is set)",
           "default": false
         },
         "includeConfigurations": {


### PR DESCRIPTION
Enables automatic FileGroup import in Developer Mode, simplifying local development setups that require the original FileGroup structure.

Adds `autoRemap` strategy, which auto-detects data paths and generates unique .ndf file paths.

Introduces `removeToPrimary` strategy, providing an option to skip FileGroups and remap objects to PRIMARY for simpler setups.

Updates documentation and example configuration.
