### PR TITLE
Add .claude/worktrees/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ DbScripts/**
 .local/
 
 .claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
## Summary
- Prevent Claude Code worktree directories from being tracked in git