### PR TITLE
Move CLAUDE.md to .claude/ and update copilot-instructions

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -1,0 +1,14 @@
+# Claude Code Instructions
+
+See `.github/copilot-instructions.md` for full project context, architecture, code conventions, and critical patterns. All instructions there apply here.
+
+## Git workflow
+
+### Worktrees and branch naming
+`EnterWorktree` auto-names the branch with a `worktree-` prefix. Always rename it immediately after the worktree is created, before doing any other work:
+
+```bash
+git branch -m worktree-feature/<name> feature/<name>
+```
+
+Feature branches must follow the format `feature/<branch-name>`.


### PR DESCRIPTION
## Summary

- Moves `CLAUDE.md` from project root to `.claude/CLAUDE.md` (both locations are loaded by Claude Code; `.claude/` keeps Claude config files together and is not broadly gitignored)
- Updates `copilot-instructions.md` with clarifications accumulated since last commit: dot-sourcing rule scope note, Docker checklist for integration tests, two-category test structure, removed stale line number references

## Notes

The path reference in `CLAUDE.md` (`See .github/copilot-instructions.md`) does not need updating — it is descriptive text, not a programmatic import, and Claude Code resolves it from the project working directory regardless of where `CLAUDE.md` lives.