### PR TITLE
Fix ValidateOnly false 'unknown config key' warnings (#77)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@ All notable changes to Export-SqlServerSchema will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+
+**ValidateOnly false 'Unknown config key' warnings (#77)**
+- `connection.connectionStringFromEnv` no longer triggers an unknown-key warning in both Export and Import `-ValidateOnly` checks
+- `import.dependencyRetries`, `import.showSql`, and `import.useLatestExport` no longer trigger unknown-key warnings in Import `-ValidateOnly` checks
+- Root cause: the `$knownConnection` and `$knownImport` allowlists in `Test-ExportConfigKeys` / `Test-ImportConfigKeys` were incomplete when added in v1.8.0
+- New tests in `test-validate-only.ps1` (tests 25–30) verify each previously-missing key is recognized
+
 ## [1.8.0] - 2026-02-25
 
 ### Improved

--- a/Export-SqlServerSchema.ps1
+++ b/Export-SqlServerSchema.ps1
@@ -498,7 +498,7 @@ function Test-ExportConfigKeys {
   }
 
   if ($Config.connection -and $Config.connection -is [hashtable]) {
-    $knownConnection = @('serverFromEnv', 'usernameFromEnv', 'passwordFromEnv', 'trustServerCertificate', 'server')
+    $knownConnection = @('serverFromEnv', 'usernameFromEnv', 'passwordFromEnv', 'connectionStringFromEnv', 'trustServerCertificate', 'server')
     foreach ($key in $Config.connection.Keys) {
       if ($key -notin $knownConnection) {
         [void]$warnings.Add("Unknown config key: 'connection.$key'")

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -581,7 +581,7 @@ function Test-ImportConfigKeys {
   }
 
   if ($Config.connection -and $Config.connection -is [hashtable]) {
-    $knownConnection = @('serverFromEnv', 'usernameFromEnv', 'passwordFromEnv', 'trustServerCertificate', 'server')
+    $knownConnection = @('serverFromEnv', 'usernameFromEnv', 'passwordFromEnv', 'connectionStringFromEnv', 'trustServerCertificate', 'server')
     foreach ($key in $Config.connection.Keys) {
       if ($key -notin $knownConnection) {
         [void]$warnings.Add("Unknown config key: 'connection.$key'")
@@ -593,6 +593,7 @@ function Test-ImportConfigKeys {
     $knownImport = @(
       'defaultMode', 'createDatabase', 'force', 'continueOnError', 'includeData',
       'includeObjectTypes', 'excludeObjectTypes', 'excludeSchemas',
+      'dependencyRetries', 'showSql', 'useLatestExport',
       'developerMode', 'productionMode', 'encryptionSecrets', 'clr',
       'fileGroupFileSizeDefaults'
     )


### PR DESCRIPTION
## Summary
- Add `connectionStringFromEnv` to `$knownConnection` allowlist in both `Test-ExportConfigKeys` and `Test-ImportConfigKeys`
- Add `dependencyRetries`, `showSql`, and `useLatestExport` to `$knownImport` allowlist in `Test-ImportConfigKeys`
- Add 6 new test cases (12 assertions) in `test-validate-only.ps1` covering each previously-missing key individually and combined

## Test plan
- [x] All 51 validate-only tests pass (including 12 new assertions)
- [x] All 35 unit tests pass
- [x] Verified each key matches the JSON schema and runtime usage

Closes #77