### PR TITLE
Load indexes before foreign keys to fix unique index FK failures (#93)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -12,3 +12,11 @@ git branch -m worktree-feature/<name> feature/<name>
 ```
 
 Feature branches must follow the format `feature/<branch-name>`.
+
+### Starting work on a GitHub issue
+When beginning work on a GitHub issue, always do all of the following before writing any code:
+1. **Assign** the issue to yourself (`gh issue edit <number> --add-assignee @me`)
+2. **Label** it as in-progress (`gh issue edit <number> --add-label in-progress`)
+3. **Link the branch** to the issue after creating it (`gh issue develop <number> --branch feature/<branch-name>` or manually via `gh api ...`)
+
+These steps ensure visibility into active work and traceability from issue to branch to PR.

--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -137,6 +137,13 @@ jobs:
           # Final check
           docker compose exec -T sqlserver /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P Test@1234 -C -Q "SELECT 1"
 
+      - name: Run common function tests
+        shell: pwsh
+        working-directory: ./tests
+        run: |
+          Write-Host "Running common function tests..."
+          ./test-common-functions.ps1
+
       - name: Run integration tests
         shell: pwsh
         working-directory: ./tests
@@ -216,6 +223,7 @@ jobs:
           cp docs/CONFIG_REFERENCE.md release/CONFIG_REFERENCE.md
           cp export-import-config.example.yml release/
           cp export-import-config.schema.json release/
+          cp Common-SqlServerSchema.ps1 release/
           cp Export-SqlServerSchema.ps1 release/
           cp Import-SqlServerSchema.ps1 release/
           cp LICENSE.md release/

--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -89,6 +89,13 @@ jobs:
           Write-Host "Running UTF-8 BOM encoding tests..."
           ./test-utf8-bom-encoding.ps1
 
+      - name: Run common function tests
+        shell: pwsh
+        working-directory: ./tests
+        run: |
+          Write-Host "Running common function tests..."
+          ./test-common-functions.ps1
+
       - name: Run unit tests
         shell: pwsh
         working-directory: ./tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - No new parameters required — report is always generated automatically
 - New test suite: `tests/test-import-integrity-report.ps1` (77 tests; no SQL Server required)
 
+### Changed
+
+**Extract Shared Functions into Common Helper Library (#66)**
+- Created `Common-SqlServerSchema.ps1` containing 7 functions previously duplicated across Export and Import scripts
+- Extracted: `Write-Log`, `Get-EscapedSqlIdentifier`, `Invoke-WithRetry`, `Read-ExportMetadata`, `ConvertFrom-AdoConnectionString`, `Resolve-EnvCredential`, `Resolve-ConfigFile`
+- Both main scripts now dot-source the common helper at startup
+- Standardized `Write-Log` parameter name to `-Level` (Import previously used `-Severity`)
+- Standardized `Read-ExportMetadata` parameter name to `-Path` (Export used `-ExportPath`, Import used `-SourcePath`)
+- Net reduction of ~400 lines of duplicated code
+- Added `tests/test-common-functions.ps1` with 25 unit tests for all extracted functions
+
 ### Fixed
 
 **Partition Scheme Corruption in removeToPrimary Mode (#80)**

--- a/Common-SqlServerSchema.ps1
+++ b/Common-SqlServerSchema.ps1
@@ -1,0 +1,508 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Shared helper functions used by both Export-SqlServerSchema.ps1 and Import-SqlServerSchema.ps1.
+
+.DESCRIPTION
+    This file is dot-sourced by both main scripts at startup. It contains functions that are
+    identical or near-identical between Export and Import, extracted to eliminate duplication.
+
+    Functions provided:
+      - Write-Log                    : Console + file logging with severity levels
+      - Get-EscapedSqlIdentifier     : Escapes ] in SQL identifiers for bracketed notation
+      - Invoke-WithRetry             : Exponential backoff retry for transient SQL errors
+      - Read-ExportMetadata          : Reads _export_metadata.json from an export directory
+      - ConvertFrom-AdoConnectionString : Parses ADO.NET connection strings
+      - Resolve-EnvCredential        : Resolves credentials from environment variables
+      - Resolve-ConfigFile           : Auto-discovers YAML config files
+
+    This file has no param() block and no mandatory parameters, making it safe to dot-source.
+
+.NOTES
+    License: MIT
+    Repository: https://github.com/ormico/Export-SqlServerSchema
+    Issue: #66 - Extract shared functions into common helper library
+#>
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Write-Log
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Write-Log {
+  <#
+    .SYNOPSIS
+        Writes message to console and log file with timestamp.
+    .DESCRIPTION
+        Outputs the message to the console with color coding by severity level,
+        and appends a timestamped entry to $script:LogFile if set and accessible.
+    .PARAMETER Message
+        The message text to log.
+    .PARAMETER Level
+        Severity level: INFO (default), SUCCESS, WARNING, or ERROR.
+    #>
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Message,
+
+    [Parameter()]
+    [ValidateSet('INFO', 'SUCCESS', 'WARNING', 'ERROR')]
+    [string]$Level = 'INFO'
+  )
+
+  $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
+  $logEntry = "[$timestamp] [$Level] $Message"
+
+  # Write to console
+  switch ($Level) {
+    'SUCCESS' { Write-Host $Message -ForegroundColor Green }
+    'WARNING' { Write-Warning $Message }
+    'ERROR' { Write-Host $Message -ForegroundColor Red }
+    default { Write-Output $Message }
+  }
+
+  # Write to log file if available and parent directory exists
+  if ($script:LogFile -and (Test-Path (Split-Path $script:LogFile -Parent))) {
+    try {
+      Add-Content -Path $script:LogFile -Value $logEntry -Encoding UTF8 -ErrorAction SilentlyContinue
+    }
+    catch {
+      # Silently fail if log write fails - don't interrupt main operation
+    }
+  }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Get-EscapedSqlIdentifier
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Get-EscapedSqlIdentifier {
+  <#
+    .SYNOPSIS
+        Escapes a SQL Server identifier for safe use in bracketed notation.
+    .DESCRIPTION
+        SQL Server uses square brackets [] to delimit identifiers. To include a literal
+        ] character within a bracketed identifier, it must be escaped as ]].
+        This function ensures identifiers are safe from second-order SQL injection
+        via malicious object names stored in the database.
+    .PARAMETER Name
+        The identifier name to escape.
+    .OUTPUTS
+        The escaped identifier name (without surrounding brackets).
+    .EXAMPLE
+        Get-EscapedSqlIdentifier -Name 'Normal_Name'
+        # Returns: Normal_Name
+    .EXAMPLE
+        Get-EscapedSqlIdentifier -Name 'Malicious]; DROP TABLE Users;--'
+        # Returns: Malicious]]; DROP TABLE Users;--
+    #>
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$Name
+  )
+
+  # Escape ] as ]] to prevent breaking out of bracketed identifier context
+  return $Name -replace '\]', ']]'
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Invoke-WithRetry
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Invoke-WithRetry {
+  <#
+    .SYNOPSIS
+        Executes a script block with retry logic for transient failures.
+    .DESCRIPTION
+        Implements exponential backoff retry strategy for handling transient errors
+        like network timeouts, Azure SQL throttling, and connection pool issues.
+    .PARAMETER ScriptBlock
+        The script block to execute.
+    .PARAMETER MaxAttempts
+        Maximum number of attempts before giving up. Default: 3.
+    .PARAMETER InitialDelaySeconds
+        Seconds to wait before the first retry. Doubles on each subsequent retry. Default: 2.
+    .PARAMETER OperationName
+        Descriptive name for the operation, used in log messages. Default: 'Operation'.
+    #>
+  param(
+    [Parameter(Mandatory = $true)]
+    [scriptblock]$ScriptBlock,
+
+    [Parameter()]
+    [int]$MaxAttempts = 3,
+
+    [Parameter()]
+    [int]$InitialDelaySeconds = 2,
+
+    [Parameter()]
+    [string]$OperationName = 'Operation'
+  )
+
+  $attempt = 0
+  $delay = $InitialDelaySeconds
+
+  while ($attempt -lt $MaxAttempts) {
+    $attempt++
+
+    try {
+      Write-Verbose "[$OperationName] Attempt $attempt of $MaxAttempts"
+      return & $ScriptBlock
+    }
+    catch {
+      $isTransient = $false
+      $errorMessage = $_.Exception.Message
+
+      # Check for transient error patterns
+      if ($errorMessage -match 'timeout|timed out|connection.*lost|connection.*closed') {
+        $isTransient = $true
+        $errorType = 'Network timeout'
+      }
+      elseif ($errorMessage -match '40501|40613|49918|10928|10929|40197|40540|40143') {
+        # Azure SQL throttling error codes
+        $isTransient = $true
+        $errorType = 'Azure SQL throttling'
+      }
+      elseif ($errorMessage -match '1205') {
+        # Deadlock victim
+        $isTransient = $true
+        $errorType = 'Deadlock'
+      }
+      elseif ($errorMessage -match 'pooling|connection pool') {
+        $isTransient = $true
+        $errorType = 'Connection pool issue'
+      }
+      elseif ($errorMessage -match '\b(53|233|64)\b') {
+        # Transport-level errors (error codes 53, 233, 64)
+        $isTransient = $true
+        $errorType = 'Transport error'
+      }
+
+      if ($isTransient -and $attempt -lt $MaxAttempts) {
+        Write-Warning "[$OperationName] $errorType detected on attempt $attempt of $MaxAttempts"
+        Write-Warning "  Error: $errorMessage"
+        Write-Warning "  Retrying in $delay seconds..."
+        Write-Log "$OperationName failed (attempt $attempt): $errorType - $errorMessage" -Level WARNING
+
+        Start-Sleep -Seconds $delay
+
+        # Exponential backoff: double the delay for next attempt
+        $delay = $delay * 2
+      }
+      else {
+        # Non-transient error or final attempt - rethrow
+        if ($isTransient) {
+          Write-Error "[$OperationName] Failed after $MaxAttempts attempts: $errorMessage"
+          Write-Log "$OperationName failed after $MaxAttempts attempts: $errorMessage" -Level ERROR
+        }
+        throw
+      }
+    }
+  }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Read-ExportMetadata
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Read-ExportMetadata {
+  <#
+    .SYNOPSIS
+        Reads and parses export metadata from a previous export.
+    .DESCRIPTION
+        Loads the _export_metadata.json file from a previous export directory
+        and returns the parsed metadata object. Used for delta export validation,
+        change detection, and import-time FileGroup sizing.
+    .PARAMETER Path
+        Path to the export directory containing _export_metadata.json.
+    .OUTPUTS
+        Hashtable containing the parsed metadata, or $null if not found.
+    #>
+  param(
+    [Parameter(Mandatory)]
+    [string]$Path
+  )
+
+  $metadataPath = Join-Path $Path '_export_metadata.json'
+  if (-not (Test-Path $metadataPath)) {
+    Write-Verbose "No export metadata file found at: $metadataPath"
+    return $null
+  }
+
+  try {
+    $json = Get-Content -Path $metadataPath -Raw -Encoding UTF8
+    $metadata = $json | ConvertFrom-Json -AsHashtable
+    Write-Verbose "Loaded export metadata: version=$($metadata.version), objects=$($metadata.objectCount)"
+    return $metadata
+  }
+  catch {
+    Write-Warning "Failed to parse metadata file: $_"
+    return $null
+  }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# ConvertFrom-AdoConnectionString
+# ─────────────────────────────────────────────────────────────────────────────
+
+function ConvertFrom-AdoConnectionString {
+  <#
+    .SYNOPSIS
+        Parses an ADO.NET connection string into its component parts.
+    .DESCRIPTION
+        Uses System.Data.SqlClient.SqlConnectionStringBuilder to safely parse a SQL Server
+        ADO.NET connection string. Recognises all standard SQL Server key aliases including
+        alternate forms (Server/Data Source, Database/Initial Catalog, UID/User ID, etc.).
+        Throws a descriptive error for malformed strings.
+        Passwords are never emitted to verbose output or logs.
+    .PARAMETER ConnectionString
+        The ADO.NET connection string to parse.
+    .OUTPUTS
+        Hashtable: Server, Database, Username, Password (string, treat as secret),
+        TrustServerCertificate (nullable bool), IntegratedSecurity (nullable bool).
+  #>
+  param(
+    [string]$ConnectionString
+  )
+
+  $result = @{
+    Server                 = $null
+    Database               = $null
+    Username               = $null
+    Password               = $null
+    TrustServerCertificate = $null
+    IntegratedSecurity     = $null
+  }
+
+  if ([string]::IsNullOrWhiteSpace($ConnectionString)) { return $result }
+
+  $builder = $null
+  try {
+    $builder = [System.Data.SqlClient.SqlConnectionStringBuilder]::new($ConnectionString)
+  }
+  catch {
+    throw "Invalid connection string format: $($_.Exception.Message)"
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($builder.DataSource))     { $result.Server   = $builder.DataSource }
+  if (-not [string]::IsNullOrWhiteSpace($builder.InitialCatalog)) { $result.Database  = $builder.InitialCatalog }
+  if (-not [string]::IsNullOrWhiteSpace($builder.UserID))         { $result.Username  = $builder.UserID }
+  if (-not [string]::IsNullOrWhiteSpace($builder.Password))       { $result.Password  = $builder.Password }
+
+  # TrustServerCertificate: SqlConnectionStringBuilder always exposes this key with default false,
+  # so check the original string text to distinguish explicit from default.
+  if ($ConnectionString -imatch '(?:^|;)\s*TrustServerCertificate\s*=') {
+    $result.TrustServerCertificate = $builder.TrustServerCertificate
+  }
+
+  # IntegratedSecurity: only set if true (non-default), using same text-based check for consistency
+  if ($ConnectionString -imatch '(?:^|;)\s*(?:Integrated\s+Security|Trusted_Connection)\s*=') {
+    $result.IntegratedSecurity = $builder.IntegratedSecurity
+  }
+
+  return $result
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Resolve-EnvCredential
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Resolve-EnvCredential {
+  <#
+    .SYNOPSIS
+        Resolves credential and connection parameters from environment variables.
+    .DESCRIPTION
+        Builds a PSCredential from environment variable names specified via *FromEnv parameters
+        or config file connection section. Follows precedence (high to low):
+          1. Explicit -Credential / -Server / -Database command-line parameters
+          2. Individual *FromEnv CLI parameters (-ServerFromEnv, -UsernameFromEnv, -PasswordFromEnv)
+          3. -ConnectionStringFromEnv CLI parameter (full ADO.NET connection string in env var)
+          4. Config file connection: section equivalents
+          5. Defaults (Windows auth, no overrides)
+    .OUTPUTS
+        Hashtable with resolved Server, Database, Credential, and TrustServerCertificate values.
+  #>
+  param(
+    [string]$ServerParam,
+    [string]$DatabaseParam,
+    [pscredential]$CredentialParam,
+    [string]$ServerFromEnvParam,
+    [string]$UsernameFromEnvParam,
+    [string]$PasswordFromEnvParam,
+    [string]$ConnectionStringFromEnvParam,
+    [bool]$TrustServerCertificateParam,
+    [hashtable]$Config,
+    [hashtable]$BoundParameters
+  )
+
+  $result = @{
+    Server                 = $ServerParam
+    Database               = $DatabaseParam
+    Credential             = $CredentialParam
+    TrustServerCertificate = $TrustServerCertificateParam
+  }
+
+  # --- Resolve TrustServerCertificate ---
+  # CLI switch > config connection section > config root-level > connection string > default (false)
+  $trustResolvedFromHigherPriority = $BoundParameters.ContainsKey('TrustServerCertificate')
+  if (-not $trustResolvedFromHigherPriority) {
+    $trustResolved = $false
+    if ($Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
+      if ($Config.connection.ContainsKey('trustServerCertificate')) {
+        $result.TrustServerCertificate = [bool]$Config.connection.trustServerCertificate
+        $trustResolved = $true
+        $trustResolvedFromHigherPriority = $true
+      }
+    }
+    # Only fall back to root-level if connection section didn't specify it
+    if (-not $trustResolved -and $Config -and $Config.ContainsKey('trustServerCertificate')) {
+      $result.TrustServerCertificate = [bool]$Config.trustServerCertificate
+      $trustResolvedFromHigherPriority = $true
+    }
+  }
+
+  # --- Resolve Server from individual *FromEnv ---
+  # CLI -Server > -ServerFromEnv > config connection.serverFromEnv
+  $serverResolvedFromHigherPriority = $BoundParameters.ContainsKey('Server') -and -not [string]::IsNullOrWhiteSpace($ServerParam)
+  if (-not $serverResolvedFromHigherPriority) {
+    $serverEnvName = $ServerFromEnvParam
+    if (-not $serverEnvName -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
+      if ($Config.connection.ContainsKey('serverFromEnv')) {
+        $serverEnvName = $Config.connection.serverFromEnv
+      }
+    }
+
+    if ($serverEnvName) {
+      $envValue = [System.Environment]::GetEnvironmentVariable($serverEnvName)
+      if ([string]::IsNullOrWhiteSpace($envValue)) {
+        throw "Environment variable '$serverEnvName' (specified via ServerFromEnv) is not set or is empty."
+      }
+      $result.Server = $envValue
+      $serverResolvedFromHigherPriority = $true
+      Write-Verbose "[ENV] Server resolved from environment variable '$serverEnvName'"
+    }
+  }
+
+  # --- Resolve Credential from individual *FromEnv ---
+  # CLI -Credential > *FromEnv params > config connection.*FromEnv
+  $credResolvedFromHigherPriority = $BoundParameters.ContainsKey('Credential') -and $null -ne $CredentialParam
+  if (-not $credResolvedFromHigherPriority) {
+    $usernameEnvName = $UsernameFromEnvParam
+    $passwordEnvName = $PasswordFromEnvParam
+
+    # Fall back to config file connection section
+    if ($Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
+      if (-not $usernameEnvName -and $Config.connection.ContainsKey('usernameFromEnv')) {
+        $usernameEnvName = $Config.connection.usernameFromEnv
+      }
+      if (-not $passwordEnvName -and $Config.connection.ContainsKey('passwordFromEnv')) {
+        $passwordEnvName = $Config.connection.passwordFromEnv
+      }
+    }
+
+    # Both username and password env vars must be specified together
+    if ($usernameEnvName -or $passwordEnvName) {
+      if (-not $usernameEnvName) {
+        throw "PasswordFromEnv is specified but UsernameFromEnv is missing. Both are required for SQL authentication."
+      }
+      if (-not $passwordEnvName) {
+        throw "UsernameFromEnv is specified but PasswordFromEnv is missing. Both are required for SQL authentication."
+      }
+
+      $usernameValue = [System.Environment]::GetEnvironmentVariable($usernameEnvName)
+      $passwordValue = [System.Environment]::GetEnvironmentVariable($passwordEnvName)
+
+      if ([string]::IsNullOrWhiteSpace($usernameValue)) {
+        throw "Environment variable '$usernameEnvName' (specified via UsernameFromEnv) is not set or is empty."
+      }
+      if ([string]::IsNullOrWhiteSpace($passwordValue)) {
+        throw "Environment variable '$passwordEnvName' (specified via PasswordFromEnv) is not set or is empty."
+      }
+
+      $securePassword = ConvertTo-SecureString $passwordValue -AsPlainText -Force
+      $result.Credential = [System.Management.Automation.PSCredential]::new($usernameValue, $securePassword)
+      $credResolvedFromHigherPriority = $true
+      Write-Verbose "[ENV] Credential resolved from environment variables '$usernameEnvName' and '$passwordEnvName'"
+    }
+  }
+
+  # --- Resolve from ConnectionStringFromEnv (lower priority than individual *FromEnv params) ---
+  # CLI -ConnectionStringFromEnv > config connection.connectionStringFromEnv
+  $connStrEnvName = $ConnectionStringFromEnvParam
+  if (-not $connStrEnvName -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
+    if ($Config.connection.ContainsKey('connectionStringFromEnv')) {
+      $connStrEnvName = $Config.connection.connectionStringFromEnv
+    }
+  }
+
+  if ($connStrEnvName) {
+    $connStrValue = [System.Environment]::GetEnvironmentVariable($connStrEnvName)
+    if ([string]::IsNullOrWhiteSpace($connStrValue)) {
+      throw "Environment variable '$connStrEnvName' (specified via ConnectionStringFromEnv) is not set or is empty."
+    }
+
+    $parsed = ConvertFrom-AdoConnectionString -ConnectionString $connStrValue
+
+    # Apply connection string values only for fields not already resolved by higher-priority sources
+    if (-not $serverResolvedFromHigherPriority -and -not [string]::IsNullOrWhiteSpace($parsed.Server)) {
+      $result.Server = $parsed.Server
+      Write-Verbose "[ENV] Server resolved from connection string in environment variable '$connStrEnvName'"
+    }
+
+    $databaseResolvedFromHigherPriority = $BoundParameters.ContainsKey('Database') -and -not [string]::IsNullOrWhiteSpace($DatabaseParam)
+    if (-not $databaseResolvedFromHigherPriority -and -not [string]::IsNullOrWhiteSpace($parsed.Database)) {
+      $result.Database = $parsed.Database
+      Write-Verbose "[ENV] Database resolved from connection string in environment variable '$connStrEnvName'"
+    }
+
+    if (-not $credResolvedFromHigherPriority -and -not [string]::IsNullOrWhiteSpace($parsed.Username) -and -not [string]::IsNullOrWhiteSpace($parsed.Password)) {
+      $securePassword = ConvertTo-SecureString $parsed.Password -AsPlainText -Force
+      $result.Credential = [System.Management.Automation.PSCredential]::new($parsed.Username, $securePassword)
+      # NOTE: password is intentionally not logged
+      Write-Verbose "[ENV] Credential resolved from connection string in environment variable '$connStrEnvName' (username: $($parsed.Username))"
+    }
+
+    if (-not $trustResolvedFromHigherPriority -and $null -ne $parsed.TrustServerCertificate) {
+      $result.TrustServerCertificate = $parsed.TrustServerCertificate
+    }
+  }
+
+  return $result
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Resolve-ConfigFile
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Resolve-ConfigFile {
+  <#
+    .SYNOPSIS
+        Auto-discovers the config file when -ConfigFile is not provided.
+    .DESCRIPTION
+        Searches for well-known config file names in the script directory first,
+        then the current working directory. Returns the first match found, or an
+        empty string if no config file is discovered.
+    .PARAMETER ScriptRoot
+        The directory containing the script (typically $PSScriptRoot).
+    .OUTPUTS
+        The resolved absolute path to the config file, or empty string if not found.
+    #>
+  param(
+    [string]$ScriptRoot
+  )
+
+  $wellKnownNames = @('export-import-config.yml', 'export-import-config.yaml')
+  $searchPaths = @($ScriptRoot, $PWD.Path)
+
+  foreach ($searchPath in $searchPaths) {
+    if (-not $searchPath) { continue }
+    foreach ($name in $wellKnownNames) {
+      $candidate = Join-Path $searchPath $name
+      if (Test-Path -LiteralPath $candidate -PathType Leaf) {
+        return $candidate
+      }
+    }
+  }
+
+  return ''
+}

--- a/Export-SqlServerSchema.ps1
+++ b/Export-SqlServerSchema.ps1
@@ -214,6 +214,9 @@ param(
 
 $ErrorActionPreference = 'Stop'
 
+# Load shared helper functions used by both Export and Import scripts
+. "$PSScriptRoot\Common-SqlServerSchema.ps1"
+
 # Early module load - required for SMO type resolution in function definitions
 try {
   $sqlModule = Get-Module -ListAvailable -Name SqlServer | Sort-Object Version -Descending | Select-Object -First 1
@@ -224,231 +227,6 @@ try {
 catch {
   # Will be handled properly in Test-Dependencies
 }
-
-#region Credential Resolution from Environment Variables
-
-function ConvertFrom-AdoConnectionString {
-  <#
-    .SYNOPSIS
-        Parses an ADO.NET connection string into its component parts.
-    .DESCRIPTION
-        Uses System.Data.SqlClient.SqlConnectionStringBuilder to safely parse a SQL Server
-        ADO.NET connection string. Recognises all standard SQL Server key aliases including
-        alternate forms (Server/Data Source, Database/Initial Catalog, UID/User ID, etc.).
-        Throws a descriptive error for malformed strings.
-        Passwords are never emitted to verbose output or logs.
-    .PARAMETER ConnectionString
-        The ADO.NET connection string to parse.
-    .OUTPUTS
-        Hashtable: Server, Database, Username, Password (string, treat as secret),
-        TrustServerCertificate (nullable bool), IntegratedSecurity (nullable bool).
-  #>
-  param(
-    [string]$ConnectionString
-  )
-
-  $result = @{
-    Server                 = $null
-    Database               = $null
-    Username               = $null
-    Password               = $null
-    TrustServerCertificate = $null
-    IntegratedSecurity     = $null
-  }
-
-  if ([string]::IsNullOrWhiteSpace($ConnectionString)) { return $result }
-
-  $builder = $null
-  try {
-    $builder = [System.Data.SqlClient.SqlConnectionStringBuilder]::new($ConnectionString)
-  }
-  catch {
-    throw "Invalid connection string format: $($_.Exception.Message)"
-  }
-
-  if (-not [string]::IsNullOrWhiteSpace($builder.DataSource))     { $result.Server   = $builder.DataSource }
-  if (-not [string]::IsNullOrWhiteSpace($builder.InitialCatalog)) { $result.Database  = $builder.InitialCatalog }
-  if (-not [string]::IsNullOrWhiteSpace($builder.UserID))         { $result.Username  = $builder.UserID }
-  if (-not [string]::IsNullOrWhiteSpace($builder.Password))       { $result.Password  = $builder.Password }
-
-  # TrustServerCertificate: SqlConnectionStringBuilder always exposes this key with default false,
-  # so check the original string text to distinguish explicit from default.
-  if ($ConnectionString -imatch '(?:^|;)\s*TrustServerCertificate\s*=') {
-    $result.TrustServerCertificate = $builder.TrustServerCertificate
-  }
-
-  # IntegratedSecurity: only set if true (non-default), using same text-based check for consistency
-  if ($ConnectionString -imatch '(?:^|;)\s*(?:Integrated\s+Security|Trusted_Connection)\s*=') {
-    $result.IntegratedSecurity = $builder.IntegratedSecurity
-  }
-
-  return $result
-}
-
-function Resolve-EnvCredential {
-  <#
-    .SYNOPSIS
-        Resolves credential and connection parameters from environment variables.
-    .DESCRIPTION
-        Builds a PSCredential from environment variable names specified via *FromEnv parameters
-        or config file connection section. Follows precedence (high to low):
-          1. Explicit -Credential / -Server / -Database command-line parameters
-          2. Individual *FromEnv CLI parameters (-ServerFromEnv, -UsernameFromEnv, -PasswordFromEnv)
-          3. -ConnectionStringFromEnv CLI parameter (full ADO.NET connection string in env var)
-          4. Config file connection: section equivalents
-          5. Defaults (Windows auth, no overrides)
-    .OUTPUTS
-        Hashtable with resolved Server, Database, Credential, and TrustServerCertificate values.
-  #>
-  param(
-    [string]$ServerParam,
-    [string]$DatabaseParam,
-    [pscredential]$CredentialParam,
-    [string]$ServerFromEnvParam,
-    [string]$UsernameFromEnvParam,
-    [string]$PasswordFromEnvParam,
-    [string]$ConnectionStringFromEnvParam,
-    [bool]$TrustServerCertificateParam,
-    [hashtable]$Config,
-    [hashtable]$BoundParameters
-  )
-
-  $result = @{
-    Server                 = $ServerParam
-    Database               = $DatabaseParam
-    Credential             = $CredentialParam
-    TrustServerCertificate = $TrustServerCertificateParam
-  }
-
-  # --- Resolve TrustServerCertificate ---
-  # CLI switch > config connection section > config root-level > connection string > default (false)
-  $trustResolvedFromHigherPriority = $BoundParameters.ContainsKey('TrustServerCertificate')
-  if (-not $trustResolvedFromHigherPriority) {
-    $trustResolved = $false
-    if ($Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
-      if ($Config.connection.ContainsKey('trustServerCertificate')) {
-        $result.TrustServerCertificate = [bool]$Config.connection.trustServerCertificate
-        $trustResolved = $true
-        $trustResolvedFromHigherPriority = $true
-      }
-    }
-    # Only fall back to root-level if connection section didn't specify it
-    if (-not $trustResolved -and $Config -and $Config.ContainsKey('trustServerCertificate')) {
-      $result.TrustServerCertificate = [bool]$Config.trustServerCertificate
-      $trustResolvedFromHigherPriority = $true
-    }
-  }
-
-  # --- Resolve Server from individual *FromEnv ---
-  # CLI -Server > -ServerFromEnv > config connection.serverFromEnv
-  $serverResolvedFromHigherPriority = $BoundParameters.ContainsKey('Server') -and -not [string]::IsNullOrWhiteSpace($ServerParam)
-  if (-not $serverResolvedFromHigherPriority) {
-    $serverEnvName = $ServerFromEnvParam
-    if (-not $serverEnvName -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
-      if ($Config.connection.ContainsKey('serverFromEnv')) {
-        $serverEnvName = $Config.connection.serverFromEnv
-      }
-    }
-
-    if ($serverEnvName) {
-      $envValue = [System.Environment]::GetEnvironmentVariable($serverEnvName)
-      if ([string]::IsNullOrWhiteSpace($envValue)) {
-        throw "Environment variable '$serverEnvName' (specified via ServerFromEnv) is not set or is empty."
-      }
-      $result.Server = $envValue
-      $serverResolvedFromHigherPriority = $true
-      Write-Verbose "[ENV] Server resolved from environment variable '$serverEnvName'"
-    }
-  }
-
-  # --- Resolve Credential from individual *FromEnv ---
-  # CLI -Credential > *FromEnv params > config connection.*FromEnv
-  $credResolvedFromHigherPriority = $BoundParameters.ContainsKey('Credential') -and $null -ne $CredentialParam
-  if (-not $credResolvedFromHigherPriority) {
-    $usernameEnvName = $UsernameFromEnvParam
-    $passwordEnvName = $PasswordFromEnvParam
-
-    # Fall back to config file connection section
-    if ($Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
-      if (-not $usernameEnvName -and $Config.connection.ContainsKey('usernameFromEnv')) {
-        $usernameEnvName = $Config.connection.usernameFromEnv
-      }
-      if (-not $passwordEnvName -and $Config.connection.ContainsKey('passwordFromEnv')) {
-        $passwordEnvName = $Config.connection.passwordFromEnv
-      }
-    }
-
-    # Both username and password env vars must be specified together
-    if ($usernameEnvName -or $passwordEnvName) {
-      if (-not $usernameEnvName) {
-        throw "PasswordFromEnv is specified but UsernameFromEnv is missing. Both are required for SQL authentication."
-      }
-      if (-not $passwordEnvName) {
-        throw "UsernameFromEnv is specified but PasswordFromEnv is missing. Both are required for SQL authentication."
-      }
-
-      $usernameValue = [System.Environment]::GetEnvironmentVariable($usernameEnvName)
-      $passwordValue = [System.Environment]::GetEnvironmentVariable($passwordEnvName)
-
-      if ([string]::IsNullOrWhiteSpace($usernameValue)) {
-        throw "Environment variable '$usernameEnvName' (specified via UsernameFromEnv) is not set or is empty."
-      }
-      if ([string]::IsNullOrWhiteSpace($passwordValue)) {
-        throw "Environment variable '$passwordEnvName' (specified via PasswordFromEnv) is not set or is empty."
-      }
-
-      $securePassword = ConvertTo-SecureString $passwordValue -AsPlainText -Force
-      $result.Credential = [System.Management.Automation.PSCredential]::new($usernameValue, $securePassword)
-      $credResolvedFromHigherPriority = $true
-      Write-Verbose "[ENV] Credential resolved from environment variables '$usernameEnvName' and '$passwordEnvName'"
-    }
-  }
-
-  # --- Resolve from ConnectionStringFromEnv (lower priority than individual *FromEnv params) ---
-  # CLI -ConnectionStringFromEnv > config connection.connectionStringFromEnv
-  $connStrEnvName = $ConnectionStringFromEnvParam
-  if (-not $connStrEnvName -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
-    if ($Config.connection.ContainsKey('connectionStringFromEnv')) {
-      $connStrEnvName = $Config.connection.connectionStringFromEnv
-    }
-  }
-
-  if ($connStrEnvName) {
-    $connStrValue = [System.Environment]::GetEnvironmentVariable($connStrEnvName)
-    if ([string]::IsNullOrWhiteSpace($connStrValue)) {
-      throw "Environment variable '$connStrEnvName' (specified via ConnectionStringFromEnv) is not set or is empty."
-    }
-
-    $parsed = ConvertFrom-AdoConnectionString -ConnectionString $connStrValue
-
-    # Apply connection string values only for fields not already resolved by higher-priority sources
-    if (-not $serverResolvedFromHigherPriority -and -not [string]::IsNullOrWhiteSpace($parsed.Server)) {
-      $result.Server = $parsed.Server
-      Write-Verbose "[ENV] Server resolved from connection string in environment variable '$connStrEnvName'"
-    }
-
-    $databaseResolvedFromHigherPriority = $BoundParameters.ContainsKey('Database') -and -not [string]::IsNullOrWhiteSpace($DatabaseParam)
-    if (-not $databaseResolvedFromHigherPriority -and -not [string]::IsNullOrWhiteSpace($parsed.Database)) {
-      $result.Database = $parsed.Database
-      Write-Verbose "[ENV] Database resolved from connection string in environment variable '$connStrEnvName'"
-    }
-
-    if (-not $credResolvedFromHigherPriority -and -not [string]::IsNullOrWhiteSpace($parsed.Username) -and -not [string]::IsNullOrWhiteSpace($parsed.Password)) {
-      $securePassword = ConvertTo-SecureString $parsed.Password -AsPlainText -Force
-      $result.Credential = [System.Management.Automation.PSCredential]::new($parsed.Username, $securePassword)
-      # NOTE: password is intentionally not logged
-      Write-Verbose "[ENV] Credential resolved from connection string in environment variable '$connStrEnvName' (username: $($parsed.Username))"
-    }
-
-    if (-not $trustResolvedFromHigherPriority -and $null -ne $parsed.TrustServerCertificate) {
-      $result.TrustServerCertificate = $parsed.TrustServerCertificate
-    }
-  }
-
-  return $result
-}
-
-#endregion
 
 #region Validation Functions
 
@@ -4054,41 +3832,6 @@ function Save-ExportMetadata {
   Write-Output "[SUCCESS] Export metadata saved: _export_metadata.json ($($objects.Count) objects tracked)"
 }
 
-function Read-ExportMetadata {
-  <#
-    .SYNOPSIS
-        Reads and parses export metadata from a previous export.
-    .DESCRIPTION
-        Loads the _export_metadata.json file from a previous export directory
-        and returns the parsed metadata object. Used for delta export validation
-        and change detection.
-    .PARAMETER ExportPath
-        Path to the previous export directory.
-    .OUTPUTS
-        Hashtable containing the parsed metadata, or $null if not found.
-  #>
-  param(
-    [Parameter(Mandatory)]
-    [string]$ExportPath
-  )
-
-  $metadataPath = Join-Path $ExportPath '_export_metadata.json'
-
-  if (-not (Test-Path $metadataPath)) {
-    return $null
-  }
-
-  try {
-    $json = Get-Content -Path $metadataPath -Raw -Encoding UTF8
-    $metadata = $json | ConvertFrom-Json -AsHashtable
-    return $metadata
-  }
-  catch {
-    Write-Warning "Failed to parse metadata file: $_"
-    return $null
-  }
-}
-
 function Get-EncryptionObjectsMetadata {
   <#
     .SYNOPSIS
@@ -4278,7 +4021,7 @@ function Test-DeltaExportCompatibility {
   }
 
   # Check 2: Metadata file exists and is valid
-  $metadata = Read-ExportMetadata -ExportPath $DeltaFromPath
+  $metadata = Read-ExportMetadata -Path $DeltaFromPath
   if ($null -eq $metadata) {
     [void]$result.Errors.Add("Previous export is missing _export_metadata.json file. Delta export requires metadata from the base export. The base export may be from an older version that did not generate metadata.")
     $result.IsValid = $false
@@ -5060,123 +4803,6 @@ function Save-PerformanceMetrics {
   Write-Output ''
 }
 
-function Write-Log {
-  <#
-    .SYNOPSIS
-        Writes message to console and log file with timestamp.
-    #>
-  param(
-    [string]$Message,
-    [ValidateSet('INFO', 'SUCCESS', 'WARNING', 'ERROR')]
-    [string]$Level = 'INFO'
-  )
-
-  $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
-  $logEntry = "[$timestamp] [$Level] $Message"
-
-  # Write to console (existing behavior)
-  switch ($Level) {
-    'SUCCESS' { Write-Host $Message -ForegroundColor Green }
-    'WARNING' { Write-Warning $Message }
-    'ERROR' { Write-Host $Message -ForegroundColor Red }
-    default { Write-Output $Message }
-  }
-
-  # Also write to log file if available
-  if ($script:LogFile -and (Test-Path (Split-Path $script:LogFile -Parent))) {
-    try {
-      Add-Content -Path $script:LogFile -Value $logEntry -Encoding UTF8 -ErrorAction SilentlyContinue
-    }
-    catch {
-      # Silently fail if log write fails - don't interrupt main operation
-    }
-  }
-}
-
-function Invoke-WithRetry {
-  <#
-    .SYNOPSIS
-        Executes a script block with retry logic for transient failures.
-    .DESCRIPTION
-        Implements exponential backoff retry strategy for handling transient errors
-        like network timeouts, Azure SQL throttling, and connection pool issues.
-    #>
-  param(
-    [Parameter(Mandatory = $true)]
-    [scriptblock]$ScriptBlock,
-
-    [Parameter()]
-    [int]$MaxAttempts = 3,
-
-    [Parameter()]
-    [int]$InitialDelaySeconds = 2,
-
-    [Parameter()]
-    [string]$OperationName = 'Operation'
-  )
-
-  $attempt = 0
-  $delay = $InitialDelaySeconds
-
-  while ($attempt -lt $MaxAttempts) {
-    $attempt++
-
-    try {
-      Write-Verbose "[$OperationName] Attempt $attempt of $MaxAttempts"
-      return & $ScriptBlock
-    }
-    catch {
-      $isTransient = $false
-      $errorMessage = $_.Exception.Message
-
-      # Check for transient error patterns
-      if ($errorMessage -match 'timeout|timed out|connection.*lost|connection.*closed') {
-        $isTransient = $true
-        $errorType = 'Network timeout'
-      }
-      elseif ($errorMessage -match '40501|40613|49918|10928|10929|40197|40540|40143') {
-        # Azure SQL throttling error codes
-        $isTransient = $true
-        $errorType = 'Azure SQL throttling'
-      }
-      elseif ($errorMessage -match '1205') {
-        # Deadlock victim
-        $isTransient = $true
-        $errorType = 'Deadlock'
-      }
-      elseif ($errorMessage -match 'pooling|connection pool') {
-        $isTransient = $true
-        $errorType = 'Connection pool issue'
-      }
-      elseif ($errorMessage -match '\b(53|233|64)\b') {
-        # Transport-level errors (error codes 53, 233, 64)
-        $isTransient = $true
-        $errorType = 'Transport error'
-      }
-
-      if ($isTransient -and $attempt -lt $MaxAttempts) {
-        Write-Warning "[$OperationName] $errorType detected on attempt $attempt of $MaxAttempts"
-        Write-Warning "  Error: $errorMessage"
-        Write-Warning "  Retrying in $delay seconds..."
-        Write-Log "$OperationName failed (attempt $attempt): $errorType - $errorMessage" -Level WARNING
-
-        Start-Sleep -Seconds $delay
-
-        # Exponential backoff: double the delay for next attempt
-        $delay = $delay * 2
-      }
-      else {
-        # Non-transient error or final attempt - rethrow
-        if ($isTransient) {
-          Write-Error "[$OperationName] Failed after $MaxAttempts attempts: $errorMessage"
-          Write-Log "$OperationName failed after $MaxAttempts attempts: $errorMessage" -Level ERROR
-        }
-        throw
-      }
-    }
-  }
-}
-
 function Write-ExportError {
   <#
     .SYNOPSIS
@@ -5682,39 +5308,6 @@ function Apply-FilestreamStripping {
   return $modifiedCount
 }
 
-function Resolve-ConfigFile {
-  <#
-    .SYNOPSIS
-        Auto-discovers the config file when -ConfigFile is not provided.
-    .DESCRIPTION
-        Searches for well-known config file names in the script directory first,
-        then the current working directory. Returns the first match found, or an
-        empty string if no config file is discovered.
-    .PARAMETER ScriptRoot
-        The directory containing the script (typically $PSScriptRoot).
-    .OUTPUTS
-        The resolved absolute path to the config file, or empty string if not found.
-    #>
-  param(
-    [string]$ScriptRoot
-  )
-
-  $wellKnownNames = @('export-import-config.yml', 'export-import-config.yaml')
-  $searchPaths = @($ScriptRoot, $PWD.Path)
-
-  foreach ($searchPath in $searchPaths) {
-    if (-not $searchPath) { continue }
-    foreach ($name in $wellKnownNames) {
-      $candidate = Join-Path $searchPath $name
-      if (Test-Path -LiteralPath $candidate -PathType Leaf) {
-        return $candidate
-      }
-    }
-  }
-
-  return ''
-}
-
 function Import-YamlConfig {
   <#
     .SYNOPSIS
@@ -6070,35 +5663,6 @@ function Test-ObjectExcluded {
   }
 
   return $false
-}
-
-function Get-EscapedSqlIdentifier {
-  <#
-    .SYNOPSIS
-        Escapes a SQL Server identifier for safe use in bracketed notation.
-    .DESCRIPTION
-        SQL Server uses square brackets [] to delimit identifiers. To include a literal
-        ] character within a bracketed identifier, it must be escaped as ]].
-        This function ensures identifiers are safe from second-order SQL injection
-        via malicious object names stored in the database.
-    .PARAMETER Name
-        The identifier name to escape.
-    .OUTPUTS
-        The escaped identifier name (without surrounding brackets).
-    .EXAMPLE
-        Get-EscapedSqlIdentifier -Name 'Normal_Name'
-        # Returns: Normal_Name
-    .EXAMPLE
-        Get-EscapedSqlIdentifier -Name 'Malicious]; DROP TABLE Users;--'
-        # Returns: Malicious]]; DROP TABLE Users;--
-    #>
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$Name
-  )
-
-  # Escape ] as ]] to prevent breaking out of bracketed identifier context
-  return $Name -replace '\]', ']]'
 }
 
 function Get-ObjectGroupingMode {

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -253,6 +253,10 @@ param(
 )
 
 $ErrorActionPreference = if ($ContinueOnError) { 'Continue' } else { 'Stop' }
+
+# Load shared helper functions used by both Export and Import scripts
+. "$PSScriptRoot\Common-SqlServerSchema.ps1"
+
 $script:LogFile = $null  # Will be set during import
 
 # Store IncludeObjectTypes parameter at script level for use in Get-ScriptFiles
@@ -464,7 +468,7 @@ function Export-IntegrityReport {
   }
 
   # Read export metadata to get exported object count and list
-  $metadata = Read-ExportMetadata -SourcePath $SourcePath
+  $metadata = Read-ExportMetadata -Path $SourcePath
   $exportedObjects = @()
   $exportedObjectCount = 0
   $metadataSource = $null
@@ -554,231 +558,6 @@ function Export-IntegrityReport {
   catch {
     Write-Warning "[WARNING] Failed to write integrity report: $_"
   }
-}
-
-#endregion
-
-#region Credential Resolution from Environment Variables
-
-function ConvertFrom-AdoConnectionString {
-  <#
-    .SYNOPSIS
-        Parses an ADO.NET connection string into its component parts.
-    .DESCRIPTION
-        Uses System.Data.SqlClient.SqlConnectionStringBuilder to safely parse a SQL Server
-        ADO.NET connection string. Recognises all standard SQL Server key aliases including
-        alternate forms (Server/Data Source, Database/Initial Catalog, UID/User ID, etc.).
-        Throws a descriptive error for malformed strings.
-        Passwords are never emitted to verbose output or logs.
-    .PARAMETER ConnectionString
-        The ADO.NET connection string to parse.
-    .OUTPUTS
-        Hashtable: Server, Database, Username, Password (string, treat as secret),
-        TrustServerCertificate (nullable bool), IntegratedSecurity (nullable bool).
-  #>
-  param(
-    [string]$ConnectionString
-  )
-
-  $result = @{
-    Server                 = $null
-    Database               = $null
-    Username               = $null
-    Password               = $null
-    TrustServerCertificate = $null
-    IntegratedSecurity     = $null
-  }
-
-  if ([string]::IsNullOrWhiteSpace($ConnectionString)) { return $result }
-
-  $builder = $null
-  try {
-    $builder = [System.Data.SqlClient.SqlConnectionStringBuilder]::new($ConnectionString)
-  }
-  catch {
-    throw "Invalid connection string format: $($_.Exception.Message)"
-  }
-
-  if (-not [string]::IsNullOrWhiteSpace($builder.DataSource))     { $result.Server   = $builder.DataSource }
-  if (-not [string]::IsNullOrWhiteSpace($builder.InitialCatalog)) { $result.Database  = $builder.InitialCatalog }
-  if (-not [string]::IsNullOrWhiteSpace($builder.UserID))         { $result.Username  = $builder.UserID }
-  if (-not [string]::IsNullOrWhiteSpace($builder.Password))       { $result.Password  = $builder.Password }
-
-  # TrustServerCertificate: SqlConnectionStringBuilder always exposes this key with default false,
-  # so check the original string text to distinguish explicit from default.
-  if ($ConnectionString -imatch '(?:^|;)\s*TrustServerCertificate\s*=') {
-    $result.TrustServerCertificate = $builder.TrustServerCertificate
-  }
-
-  # IntegratedSecurity: only set if true (non-default), using same text-based check for consistency
-  if ($ConnectionString -imatch '(?:^|;)\s*(?:Integrated\s+Security|Trusted_Connection)\s*=') {
-    $result.IntegratedSecurity = $builder.IntegratedSecurity
-  }
-
-  return $result
-}
-
-function Resolve-EnvCredential {
-  <#
-    .SYNOPSIS
-        Resolves credential and connection parameters from environment variables.
-    .DESCRIPTION
-        Builds a PSCredential from environment variable names specified via *FromEnv parameters
-        or config file connection section. Follows precedence (high to low):
-          1. Explicit -Credential / -Server / -Database command-line parameters
-          2. Individual *FromEnv CLI parameters (-ServerFromEnv, -UsernameFromEnv, -PasswordFromEnv)
-          3. -ConnectionStringFromEnv CLI parameter (full ADO.NET connection string in env var)
-          4. Config file connection: section equivalents
-          5. Defaults (Windows auth, no overrides)
-    .OUTPUTS
-        Hashtable with resolved Server, Database, Credential, and TrustServerCertificate values.
-  #>
-  param(
-    [string]$ServerParam,
-    [string]$DatabaseParam,
-    [pscredential]$CredentialParam,
-    [string]$ServerFromEnvParam,
-    [string]$UsernameFromEnvParam,
-    [string]$PasswordFromEnvParam,
-    [string]$ConnectionStringFromEnvParam,
-    [bool]$TrustServerCertificateParam,
-    [hashtable]$Config,
-    [hashtable]$BoundParameters
-  )
-
-  $result = @{
-    Server                 = $ServerParam
-    Database               = $DatabaseParam
-    Credential             = $CredentialParam
-    TrustServerCertificate = $TrustServerCertificateParam
-  }
-
-  # --- Resolve TrustServerCertificate ---
-  # CLI switch > config connection section > config root-level > connection string > default (false)
-  $trustResolvedFromHigherPriority = $BoundParameters.ContainsKey('TrustServerCertificate')
-  if (-not $trustResolvedFromHigherPriority) {
-    $trustResolved = $false
-    if ($Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
-      if ($Config.connection.ContainsKey('trustServerCertificate')) {
-        $result.TrustServerCertificate = [bool]$Config.connection.trustServerCertificate
-        $trustResolved = $true
-        $trustResolvedFromHigherPriority = $true
-      }
-    }
-    # Only fall back to root-level if connection section didn't specify it
-    if (-not $trustResolved -and $Config -and $Config.ContainsKey('trustServerCertificate')) {
-      $result.TrustServerCertificate = [bool]$Config.trustServerCertificate
-      $trustResolvedFromHigherPriority = $true
-    }
-  }
-
-  # --- Resolve Server from individual *FromEnv ---
-  # CLI -Server > -ServerFromEnv > config connection.serverFromEnv
-  $serverResolvedFromHigherPriority = $BoundParameters.ContainsKey('Server') -and -not [string]::IsNullOrWhiteSpace($ServerParam)
-  if (-not $serverResolvedFromHigherPriority) {
-    $serverEnvName = $ServerFromEnvParam
-    if (-not $serverEnvName -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
-      if ($Config.connection.ContainsKey('serverFromEnv')) {
-        $serverEnvName = $Config.connection.serverFromEnv
-      }
-    }
-
-    if ($serverEnvName) {
-      $envValue = [System.Environment]::GetEnvironmentVariable($serverEnvName)
-      if ([string]::IsNullOrWhiteSpace($envValue)) {
-        throw "Environment variable '$serverEnvName' (specified via ServerFromEnv) is not set or is empty."
-      }
-      $result.Server = $envValue
-      $serverResolvedFromHigherPriority = $true
-      Write-Verbose "[ENV] Server resolved from environment variable '$serverEnvName'"
-    }
-  }
-
-  # --- Resolve Credential from individual *FromEnv ---
-  # CLI -Credential > *FromEnv params > config connection.*FromEnv
-  $credResolvedFromHigherPriority = $BoundParameters.ContainsKey('Credential') -and $null -ne $CredentialParam
-  if (-not $credResolvedFromHigherPriority) {
-    $usernameEnvName = $UsernameFromEnvParam
-    $passwordEnvName = $PasswordFromEnvParam
-
-    # Fall back to config file connection section
-    if ($Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
-      if (-not $usernameEnvName -and $Config.connection.ContainsKey('usernameFromEnv')) {
-        $usernameEnvName = $Config.connection.usernameFromEnv
-      }
-      if (-not $passwordEnvName -and $Config.connection.ContainsKey('passwordFromEnv')) {
-        $passwordEnvName = $Config.connection.passwordFromEnv
-      }
-    }
-
-    # Both username and password env vars must be specified together
-    if ($usernameEnvName -or $passwordEnvName) {
-      if (-not $usernameEnvName) {
-        throw "PasswordFromEnv is specified but UsernameFromEnv is missing. Both are required for SQL authentication."
-      }
-      if (-not $passwordEnvName) {
-        throw "UsernameFromEnv is specified but PasswordFromEnv is missing. Both are required for SQL authentication."
-      }
-
-      $usernameValue = [System.Environment]::GetEnvironmentVariable($usernameEnvName)
-      $passwordValue = [System.Environment]::GetEnvironmentVariable($passwordEnvName)
-
-      if ([string]::IsNullOrWhiteSpace($usernameValue)) {
-        throw "Environment variable '$usernameEnvName' (specified via UsernameFromEnv) is not set or is empty."
-      }
-      if ([string]::IsNullOrWhiteSpace($passwordValue)) {
-        throw "Environment variable '$passwordEnvName' (specified via PasswordFromEnv) is not set or is empty."
-      }
-
-      $securePassword = ConvertTo-SecureString $passwordValue -AsPlainText -Force
-      $result.Credential = [System.Management.Automation.PSCredential]::new($usernameValue, $securePassword)
-      $credResolvedFromHigherPriority = $true
-      Write-Verbose "[ENV] Credential resolved from environment variables '$usernameEnvName' and '$passwordEnvName'"
-    }
-  }
-
-  # --- Resolve from ConnectionStringFromEnv (lower priority than individual *FromEnv params) ---
-  # CLI -ConnectionStringFromEnv > config connection.connectionStringFromEnv
-  $connStrEnvName = $ConnectionStringFromEnvParam
-  if (-not $connStrEnvName -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
-    if ($Config.connection.ContainsKey('connectionStringFromEnv')) {
-      $connStrEnvName = $Config.connection.connectionStringFromEnv
-    }
-  }
-
-  if ($connStrEnvName) {
-    $connStrValue = [System.Environment]::GetEnvironmentVariable($connStrEnvName)
-    if ([string]::IsNullOrWhiteSpace($connStrValue)) {
-      throw "Environment variable '$connStrEnvName' (specified via ConnectionStringFromEnv) is not set or is empty."
-    }
-
-    $parsed = ConvertFrom-AdoConnectionString -ConnectionString $connStrValue
-
-    # Apply connection string values only for fields not already resolved by higher-priority sources
-    if (-not $serverResolvedFromHigherPriority -and -not [string]::IsNullOrWhiteSpace($parsed.Server)) {
-      $result.Server = $parsed.Server
-      Write-Verbose "[ENV] Server resolved from connection string in environment variable '$connStrEnvName'"
-    }
-
-    $databaseResolvedFromHigherPriority = $BoundParameters.ContainsKey('Database') -and -not [string]::IsNullOrWhiteSpace($DatabaseParam)
-    if (-not $databaseResolvedFromHigherPriority -and -not [string]::IsNullOrWhiteSpace($parsed.Database)) {
-      $result.Database = $parsed.Database
-      Write-Verbose "[ENV] Database resolved from connection string in environment variable '$connStrEnvName'"
-    }
-
-    if (-not $credResolvedFromHigherPriority -and -not [string]::IsNullOrWhiteSpace($parsed.Username) -and -not [string]::IsNullOrWhiteSpace($parsed.Password)) {
-      $securePassword = ConvertTo-SecureString $parsed.Password -AsPlainText -Force
-      $result.Credential = [System.Management.Automation.PSCredential]::new($parsed.Username, $securePassword)
-      # NOTE: password is intentionally not logged
-      Write-Verbose "[ENV] Credential resolved from connection string in environment variable '$connStrEnvName' (username: $($parsed.Username))"
-    }
-
-    if (-not $trustResolvedFromHigherPriority -and $null -ne $parsed.TrustServerCertificate) {
-      $result.TrustServerCertificate = $parsed.TrustServerCertificate
-    }
-  }
-
-  return $result
 }
 
 #endregion
@@ -1264,127 +1043,6 @@ function Export-Metrics {
   Write-Output "[METRICS] Saved to: $metricsFile"
 }
 
-function Write-Log {
-  <#
-    .SYNOPSIS
-        Writes log entry to console and log file.
-    #>
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$Message,
-
-    [Parameter()]
-    [ValidateSet('INFO', 'SUCCESS', 'WARNING', 'ERROR')]
-    [string]$Severity = 'INFO'
-  )
-
-  $timestamp = Get-Date -Format 'yyyy-MM-dd HH:mm:ss'
-  $logEntry = "[$timestamp] [$Severity] $Message"
-
-  # Write to console (consistent with Export script)
-  switch ($Severity) {
-    'SUCCESS' { Write-Host $Message -ForegroundColor Green }
-    'WARNING' { Write-Warning $Message }
-    'ERROR' { Write-Host $Message -ForegroundColor Red }
-    default { Write-Output $Message }
-  }
-
-  # Write to log file if available
-  if ($script:LogFile) {
-    try {
-      Add-Content -Path $script:LogFile -Value $logEntry -ErrorAction SilentlyContinue
-    }
-    catch {
-      # Silently ignore file write errors
-    }
-  }
-}
-
-function Invoke-WithRetry {
-  <#
-    .SYNOPSIS
-        Executes a script block with retry logic for transient failures.
-    .DESCRIPTION
-        Implements exponential backoff retry strategy for handling transient errors
-        like network timeouts, Azure SQL throttling, and connection pool issues.
-    #>
-  param(
-    [Parameter(Mandatory = $true)]
-    [scriptblock]$ScriptBlock,
-
-    [Parameter()]
-    [int]$MaxAttempts = 3,
-
-    [Parameter()]
-    [int]$InitialDelaySeconds = 2,
-
-    [Parameter()]
-    [string]$OperationName = 'Operation'
-  )
-
-  $attempt = 0
-  $delay = $InitialDelaySeconds
-
-  while ($attempt -lt $MaxAttempts) {
-    $attempt++
-
-    try {
-      Write-Verbose "[$OperationName] Attempt $attempt of $MaxAttempts"
-      return & $ScriptBlock
-    }
-    catch {
-      $isTransient = $false
-      $errorMessage = $_.Exception.Message
-
-      # Check for transient error patterns
-      if ($errorMessage -match 'timeout|timed out|connection.*lost|connection.*closed') {
-        $isTransient = $true
-        $errorType = 'Network timeout'
-      }
-      elseif ($errorMessage -match '40501|40613|49918|10928|10929|40197|40540|40143') {
-        # Azure SQL throttling error codes
-        $isTransient = $true
-        $errorType = 'Azure SQL throttling'
-      }
-      elseif ($errorMessage -match '1205') {
-        # Deadlock victim
-        $isTransient = $true
-        $errorType = 'Deadlock'
-      }
-      elseif ($errorMessage -match 'pooling|connection pool') {
-        $isTransient = $true
-        $errorType = 'Connection pool issue'
-      }
-      elseif ($errorMessage -match '\b(53|233|64)\b') {
-        # Transport-level errors (error codes 53, 233, 64)
-        $isTransient = $true
-        $errorType = 'Transport error'
-      }
-
-      if ($isTransient -and $attempt -lt $MaxAttempts) {
-        Write-Warning "[$OperationName] $errorType detected on attempt $attempt of $MaxAttempts"
-        Write-Warning "  Error: $errorMessage"
-        Write-Warning "  Retrying in $delay seconds..."
-        Write-Log "$OperationName failed (attempt $attempt): $errorType - $errorMessage" -Severity WARNING
-
-        Start-Sleep -Seconds $delay
-
-        # Exponential backoff: double the delay for next attempt
-        $delay = $delay * 2
-      }
-      else {
-        # Non-transient error or final attempt - rethrow
-        if ($isTransient) {
-          Write-Error "[$OperationName] Failed after $MaxAttempts attempts: $errorMessage"
-          Write-Log "$OperationName failed after $MaxAttempts attempts: $errorMessage" -Severity ERROR
-        }
-        throw
-      }
-    }
-  }
-}
-
-
 function Test-Dependencies {
   <#
     .SYNOPSIS
@@ -1770,7 +1428,7 @@ function Get-RequiredEncryptionSecrets {
   )
 
   # Try to read from metadata first (fast path)
-  $metadata = Read-ExportMetadata -SourcePath $SourcePath
+  $metadata = Read-ExportMetadata -Path $SourcePath
   if ($metadata -and $metadata.ContainsKey('encryptionObjects') -and $metadata.encryptionObjects) {
     Write-Verbose "Reading encryption objects from export metadata"
     return $metadata.encryptionObjects
@@ -1965,7 +1623,7 @@ function Show-EncryptionSecretsTemplate {
     $EncryptionObjects
   )
 
-  $metadata = Read-ExportMetadata -SourcePath $SourcePath
+  $metadata = Read-ExportMetadata -Path $SourcePath
 
   Write-Host ""
   Write-Host "=" * 70 -ForegroundColor Cyan
@@ -2132,41 +1790,6 @@ function Show-EncryptionSecretsTemplate {
   Write-Host ""
   Write-Host "For more information, see: docs/ENCRYPTION_SECRETS_DESIGN.md" -ForegroundColor DarkGray
   Write-Host ""
-}
-
-function Read-ExportMetadata {
-  <#
-    .SYNOPSIS
-        Reads export metadata from _export_metadata.json file.
-    .DESCRIPTION
-        Loads the metadata file from an export directory to retrieve original
-        FileGroup sizes, paths, and other export-time settings.
-    .PARAMETER SourcePath
-        Path to the export directory containing _export_metadata.json.
-    .OUTPUTS
-        Hashtable with metadata, or $null if file doesn't exist.
-  #>
-  param(
-    [Parameter(Mandatory)]
-    [string]$SourcePath
-  )
-
-  $metadataPath = Join-Path $SourcePath '_export_metadata.json'
-  if (-not (Test-Path $metadataPath)) {
-    Write-Verbose "No export metadata file found at: $metadataPath"
-    return $null
-  }
-
-  try {
-    $json = Get-Content -Path $metadataPath -Raw -Encoding UTF8
-    $metadata = $json | ConvertFrom-Json -AsHashtable
-    Write-Verbose "Loaded export metadata: version=$($metadata.version), objects=$($metadata.objectCount)"
-    return $metadata
-  }
-  catch {
-    Write-Warning "[WARNING] Failed to read export metadata: $_"
-    return $null
-  }
 }
 
 function Get-FileGroupFileSizeValues {
@@ -3424,35 +3047,6 @@ function Invoke-ScriptsWithDependencyRetries {
   }
 }
 
-function Get-EscapedSqlIdentifier {
-  <#
-    .SYNOPSIS
-        Escapes a SQL Server identifier for safe use in bracketed notation.
-    .DESCRIPTION
-        SQL Server uses square brackets [] to delimit identifiers. To include a literal
-        ] character within a bracketed identifier, it must be escaped as ]].
-        This function ensures identifiers are safe from second-order SQL injection
-        via malicious object names stored in the database.
-    .PARAMETER Name
-        The identifier name to escape.
-    .OUTPUTS
-        The escaped identifier name (without surrounding brackets).
-    .EXAMPLE
-        Get-EscapedSqlIdentifier -Name 'Normal_Name'
-        # Returns: Normal_Name
-    .EXAMPLE
-        Get-EscapedSqlIdentifier -Name 'Malicious]; DROP TABLE Users;--'
-        # Returns: Malicious]]; DROP TABLE Users;--
-    #>
-  param(
-    [Parameter(Mandatory = $true)]
-    [string]$Name
-  )
-
-  # Escape ] as ]] to prevent breaking out of bracketed identifier context
-  return $Name -replace '\]', ']]'
-}
-
 function Test-SchemaExcluded {
   <#
     .SYNOPSIS
@@ -4157,39 +3751,6 @@ function Resolve-LatestExportPath {
   Write-Host "[INFO] Resolved SourcePath: $($selected.Directory.FullName)" -ForegroundColor Cyan
 
   return $selected.Directory.FullName
-}
-
-function Resolve-ConfigFile {
-  <#
-    .SYNOPSIS
-        Auto-discovers the config file when -ConfigFile is not provided.
-    .DESCRIPTION
-        Searches for well-known config file names in the script directory first,
-        then the current working directory. Returns the first match found, or an
-        empty string if no config file is discovered.
-    .PARAMETER ScriptRoot
-        The directory containing the script (typically $PSScriptRoot).
-    .OUTPUTS
-        The resolved absolute path to the config file, or empty string if not found.
-    #>
-  param(
-    [string]$ScriptRoot
-  )
-
-  $wellKnownNames = @('export-import-config.yml', 'export-import-config.yaml')
-  $searchPaths = @($ScriptRoot, $PWD.Path)
-
-  foreach ($searchPath in $searchPaths) {
-    if (-not $searchPath) { continue }
-    foreach ($name in $wellKnownNames) {
-      $candidate = Join-Path $searchPath $name
-      if (Test-Path -LiteralPath $candidate -PathType Leaf) {
-        return $candidate
-      }
-    }
-  }
-
-  return ''
 }
 
 function Import-YamlConfig {
@@ -5015,12 +4576,12 @@ try {
 
   # Initialize log file
   $script:LogFile = Join-Path $SourcePath 'import-log.txt'
-  Write-Log "Import started" -Severity INFO
-  Write-Log "Server: $Server" -Severity INFO
-  Write-Log "Database: $Database" -Severity INFO
-  Write-Log "Source: $SourcePath" -Severity INFO
-  Write-Log "Import mode: $ImportMode" -Severity INFO
-  Write-Log "Configuration source: $configSource" -Severity INFO
+  Write-Log "Import started" -Level INFO
+  Write-Log "Server: $Server" -Level INFO
+  Write-Log "Database: $Database" -Level INFO
+  Write-Log "Source: $SourcePath" -Level INFO
+  Write-Log "Import mode: $ImportMode" -Level INFO
+  Write-Log "Configuration source: $configSource" -Level INFO
 
   # Validate dependencies
   $execMethod = Test-Dependencies
@@ -5049,7 +4610,7 @@ try {
   }
   catch {
     Write-Error "[ERROR] Failed to create connection: $_"
-    Write-Log "Failed to create connection to $Server" -Severity ERROR
+    Write-Log "Failed to create connection to $Server" -Level ERROR
     exit 1
   }
   if ($script:CollectMetrics) {
@@ -5062,12 +4623,12 @@ try {
   if ($script:CollectMetrics) { Write-Verbose "[TIMING] Starting Test-DatabaseConnection..." }
   $testConnSw = [System.Diagnostics.Stopwatch]::StartNew()
   if (-not (Test-DatabaseConnection -ServerName $Server -Cred $Credential -Config $config -Timeout $effectiveConnectionTimeout -Connection $script:SharedConnection)) {
-    Write-Log "Connection test failed to $Server" -Severity ERROR
+    Write-Log "Connection test failed to $Server" -Level ERROR
     exit 1
   }
   $testConnSw.Stop()
   if ($script:CollectMetrics) { Write-Verbose "[TIMING] Test-DatabaseConnection completed in $([math]::Round($testConnSw.Elapsed.TotalSeconds, 3))s" }
-  Write-Log "Connection test successful to $Server" -Severity INFO
+  Write-Log "Connection test successful to $Server" -Level INFO
   Write-Output ''
 
   # Handle -TestConnection mode: verify connectivity and exit
@@ -5235,7 +4796,7 @@ try {
   $sqlCmdVars = @{}
 
   # Read export metadata for original FileGroup values
-  $exportMetadata = Read-ExportMetadata -SourcePath $SourcePath
+  $exportMetadata = Read-ExportMetadata -Path $SourcePath
 
   # Get FileGroup file size defaults from config (if specified)
   # Use safe property access patterns for PowerShell 7.5+ compatibility
@@ -5867,7 +5428,7 @@ try {
   # Apply scripts
   Write-Output 'Applying scripts...'
   Write-Output '───────────────────────────────────────────────'
-  Write-Log "Starting script execution - $($scripts.Count) total scripts" -Severity INFO
+  Write-Log "Starting script execution - $($scripts.Count) total scripts" -Level INFO
   Write-Verbose "Total scripts to process: $($scripts.Count)"
   if ($scripts.Count -gt 0) {
     Write-Verbose "First script: $($scripts[0].FullName)"
@@ -6651,12 +6212,12 @@ try {
     }
 
     Write-Output ''
-    Write-Log "Import completed with $failureCount error(s)" -Severity ERROR
+    Write-Log "Import completed with $failureCount error(s)" -Level ERROR
   }
   else {
     Write-Output '[SUCCESS] Import completed successfully'
     Write-Output ''
-    Write-Log "Import completed successfully - $successCount script(s) executed" -Severity INFO
+    Write-Log "Import completed successfully - $successCount script(s) executed" -Level INFO
   }
 
   # Stop overall timing and export metrics
@@ -6711,7 +6272,7 @@ try {
 }
 catch {
   Write-Error "[ERROR] Script error: $($_.ToString())"
-  Write-Log "Script error: $($_.ToString())" -Severity ERROR
+  Write-Log "Script error: $($_.ToString())" -Level ERROR
 
   # Attempt to write integrity report even on unhandled errors
   if ($script:ReportSourcePath -and $Server -and $Database) {

--- a/tests/run-unit-tests.ps1
+++ b/tests/run-unit-tests.ps1
@@ -8,260 +8,227 @@
 $ErrorActionPreference = 'Stop'
 $worktreeRoot = Split-Path $PSScriptRoot -Parent
 
-# Load the two functions by extracting them from the Export script text, then dot-sourcing a temp file
-$scriptContent = Get-Content (Join-Path $worktreeRoot 'Export-SqlServerSchema.ps1') -Raw
+# Load shared functions from Common helper (safe to dot-source — no mandatory params)
+$commonScript = Join-Path $worktreeRoot 'Common-SqlServerSchema.ps1'
+. $commonScript
 
-# Write a temp file with just the two functions we want to test
-$baseTempDir = if ($env:RUNNER_TEMP) { $env:RUNNER_TEMP } else { [System.IO.Path]::GetTempPath() }
-$tempFile = Join-Path $baseTempDir "test-connstr-functions-$([System.Guid]::NewGuid().ToString('N')).ps1"
-try {
-    # Extract function blocks using brace counting
-    function Get-FunctionBlock {
-        param([string]$Content, [string]$FunctionName)
-        $startPattern = "function $FunctionName "
-        $startIndex = $Content.IndexOf($startPattern)
-        if ($startIndex -lt 0) { throw "Function '$FunctionName' not found" }
+$passed = 0
+$failed = 0
 
-        $depth = 0
-        $inFunction = $false
-        $end = $startIndex
-        for ($i = $startIndex; $i -lt $Content.Length; $i++) {
-            if ($Content[$i] -eq '{') { $depth++; $inFunction = $true }
-            elseif ($Content[$i] -eq '}') {
-                $depth--
-                if ($inFunction -and $depth -eq 0) { $end = $i; break }
-            }
-        }
-        return $Content.Substring($startIndex, $end - $startIndex + 1)
+function Assert-True {
+    param([string]$Name, [bool]$Condition, [string]$Details = '')
+    if ($Condition) {
+        Write-Host "[PASS] $Name" -ForegroundColor Green
+        $script:passed++
+    } else {
+        Write-Host "[FAIL] $Name$(if ($Details) { ": $Details" })" -ForegroundColor Red
+        $script:failed++
     }
-
-    $convertFunc = Get-FunctionBlock $scriptContent 'ConvertFrom-AdoConnectionString'
-    $resolveFunc = Get-FunctionBlock $scriptContent 'Resolve-EnvCredential'
-    "$convertFunc`n`n$resolveFunc" | Set-Content $tempFile -Encoding UTF8
-
-    . $tempFile
-
-    $passed = 0
-    $failed = 0
-
-    function Assert-True {
-        param([string]$Name, [bool]$Condition, [string]$Details = '')
-        if ($Condition) {
-            Write-Host "[PASS] $Name" -ForegroundColor Green
-            $script:passed++
-        } else {
-            Write-Host "[FAIL] $Name$(if ($Details) { ": $Details" })" -ForegroundColor Red
-            $script:failed++
-        }
-    }
-
-    Write-Host "`n=== Unit Tests: ConvertFrom-AdoConnectionString ===`n" -ForegroundColor Cyan
-
-    # Test 1: Standard SQL Server keys (Data Source, Initial Catalog, User ID, Password)
-    $r = ConvertFrom-AdoConnectionString 'Data Source=myserver,1433;Initial Catalog=mydb;User ID=myuser;Password=mypass;TrustServerCertificate=true'
-    Assert-True 'Standard keys - Server' ($r.Server -eq 'myserver,1433') "got '$($r.Server)'"
-    Assert-True 'Standard keys - Database' ($r.Database -eq 'mydb') "got '$($r.Database)'"
-    Assert-True 'Standard keys - Username' ($r.Username -eq 'myuser') "got '$($r.Username)'"
-    Assert-True 'Standard keys - Password' ($r.Password -eq 'mypass') "got '$($r.Password)'"
-    Assert-True 'Standard keys - TrustServerCertificate=true' ($r.TrustServerCertificate -eq $true) "got '$($r.TrustServerCertificate)'"
-
-    # Test 2: Alternate aliases recognized by SqlConnectionStringBuilder (Server, Database)
-    $r = ConvertFrom-AdoConnectionString 'Server=myserver2;Database=mydb2;User ID=u2;Password=p2'
-    Assert-True 'Alias Server -> DataSource' ($r.Server -eq 'myserver2') "got '$($r.Server)'"
-    Assert-True 'Alias Database -> InitialCatalog' ($r.Database -eq 'mydb2') "got '$($r.Database)'"
-    Assert-True 'User ID' ($r.Username -eq 'u2') "got '$($r.Username)'"
-    Assert-True 'Password' ($r.Password -eq 'p2') "got '$($r.Password)'"
-
-    # Test 3: TrustServerCertificate=false
-    $r = ConvertFrom-AdoConnectionString 'Data Source=srv;Initial Catalog=db;TrustServerCertificate=false'
-    Assert-True 'TrustServerCertificate=false' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
-
-    # Test 4: TrustServerCertificate not present -> null
-    $r = ConvertFrom-AdoConnectionString 'Data Source=srv;Initial Catalog=db;User ID=u;Password=p'
-    Assert-True 'TrustServerCertificate absent -> null' ($null -eq $r.TrustServerCertificate) "got '$($r.TrustServerCertificate)'"
-
-    # Test 5: Integrated Security=SSPI (Windows auth)
-    $r = ConvertFrom-AdoConnectionString 'Data Source=srv;Initial Catalog=db;Integrated Security=SSPI'
-    Assert-True 'Integrated Security=SSPI -> true' ($r.IntegratedSecurity -eq $true) "got '$($r.IntegratedSecurity)'"
-    Assert-True 'Integrated Security=SSPI -> no username' ([string]::IsNullOrEmpty($r.Username)) "Username='$($r.Username)'"
-
-    # Test 6: Malformed connection string throws descriptive error
-    try {
-        ConvertFrom-AdoConnectionString '=bad key=value' | Out-Null
-        Assert-True 'Malformed string throws' $false 'Expected exception not thrown'
-    } catch {
-        Assert-True 'Malformed string throws descriptive error' ($_.Exception.Message -match 'Invalid connection string') "got '$($_.Exception.Message)'"
-    }
-
-    # Test 7: Empty/whitespace string returns all nulls (no throw)
-    $r = ConvertFrom-AdoConnectionString '   '
-    Assert-True 'Whitespace-only string - Server null' ($null -eq $r.Server) "got '$($r.Server)'"
-    Assert-True 'Whitespace-only string - Database null' ($null -eq $r.Database) "got '$($r.Database)'"
-
-    # Test 8: Azure SQL connection string
-    $r = ConvertFrom-AdoConnectionString 'Server=tcp:myserver.database.windows.net,1433;Initial Catalog=mydb;User ID=admin@myserver;Password=Pass1234!;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30'
-    Assert-True 'Azure SQL - Server' ($r.Server -eq 'tcp:myserver.database.windows.net,1433') "got '$($r.Server)'"
-    Assert-True 'Azure SQL - Database' ($r.Database -eq 'mydb') "got '$($r.Database)'"
-    Assert-True 'Azure SQL - Username' ($r.Username -eq 'admin@myserver') "got '$($r.Username)'"
-    Assert-True 'Azure SQL - TrustServerCertificate=False' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
-
-    Write-Host "`n=== Unit Tests: Resolve-EnvCredential ConnectionString precedence ===`n" -ForegroundColor Cyan
-
-    # Test 9: ConnectionStringFromEnv resolves Server, Database, credentials, and TrustServerCertificate
-    $envVarName9 = "TEST_CONNSTR_$(Get-Random)"
-    [System.Environment]::SetEnvironmentVariable($envVarName9, 'Data Source=testserver;Initial Catalog=testdb;User ID=testuser;Password=testpass;TrustServerCertificate=true', [System.EnvironmentVariableTarget]::Process)
-    try {
-        $r = Resolve-EnvCredential `
-            -ServerParam '' -DatabaseParam '' -CredentialParam $null `
-            -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
-            -ConnectionStringFromEnvParam $envVarName9 `
-            -TrustServerCertificateParam $false `
-            -Config @{} -BoundParameters @{}
-        Assert-True 'ConnStr - Server resolved' ($r.Server -eq 'testserver') "got '$($r.Server)'"
-        Assert-True 'ConnStr - Database resolved' ($r.Database -eq 'testdb') "got '$($r.Database)'"
-        Assert-True 'ConnStr - Credential resolved' ($null -ne $r.Credential) 'Credential was null'
-        Assert-True 'ConnStr - Username in credential' ($r.Credential.UserName -eq 'testuser') "got '$($r.Credential.UserName)'"
-        Assert-True 'ConnStr - TrustServerCertificate from connstr' ($r.TrustServerCertificate -eq $true) "got '$($r.TrustServerCertificate)'"
-    } finally {
-        [System.Environment]::SetEnvironmentVariable($envVarName9, $null, [System.EnvironmentVariableTarget]::Process)
-    }
-
-    # Test 10: CLI -Server takes precedence over connection string server
-    $envVarName10 = "TEST_CONNSTR_$(Get-Random)"
-    [System.Environment]::SetEnvironmentVariable($envVarName10, 'Data Source=connstr-server;Initial Catalog=connstr-db;User ID=u;Password=p', [System.EnvironmentVariableTarget]::Process)
-    try {
-        $r = Resolve-EnvCredential `
-            -ServerParam 'cli-server' -DatabaseParam '' -CredentialParam $null `
-            -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
-            -ConnectionStringFromEnvParam $envVarName10 `
-            -TrustServerCertificateParam $false `
-            -Config @{} -BoundParameters @{ Server = 'cli-server' }
-        Assert-True 'Precedence: CLI Server > ConnStr Server' ($r.Server -eq 'cli-server') "got '$($r.Server)'"
-        Assert-True 'Precedence: Database from ConnStr (no CLI -Database)' ($r.Database -eq 'connstr-db') "got '$($r.Database)'"
-    } finally {
-        [System.Environment]::SetEnvironmentVariable($envVarName10, $null, [System.EnvironmentVariableTarget]::Process)
-    }
-
-    # Test 11: CLI -Database takes precedence over connection string database
-    $envVarName11 = "TEST_CONNSTR_$(Get-Random)"
-    [System.Environment]::SetEnvironmentVariable($envVarName11, 'Data Source=srv;Initial Catalog=connstr-db;User ID=u;Password=p', [System.EnvironmentVariableTarget]::Process)
-    try {
-        $r = Resolve-EnvCredential `
-            -ServerParam '' -DatabaseParam 'cli-database' -CredentialParam $null `
-            -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
-            -ConnectionStringFromEnvParam $envVarName11 `
-            -TrustServerCertificateParam $false `
-            -Config @{} -BoundParameters @{ Database = 'cli-database' }
-        Assert-True 'Precedence: CLI Database > ConnStr Database' ($r.Database -eq 'cli-database') "got '$($r.Database)'"
-    } finally {
-        [System.Environment]::SetEnvironmentVariable($envVarName11, $null, [System.EnvironmentVariableTarget]::Process)
-    }
-
-    # Test 12: Individual *FromEnv credentials take precedence over connection string credentials
-    $envVarName12cs = "TEST_CONNSTR_$(Get-Random)"
-    $envVarName12u  = "TEST_USER_$(Get-Random)"
-    $envVarName12p  = "TEST_PASS_$(Get-Random)"
-    [System.Environment]::SetEnvironmentVariable($envVarName12cs, 'Data Source=srv;Initial Catalog=db;User ID=wrong-user;Password=wrong-pass', [System.EnvironmentVariableTarget]::Process)
-    [System.Environment]::SetEnvironmentVariable($envVarName12u, 'correct-user', [System.EnvironmentVariableTarget]::Process)
-    [System.Environment]::SetEnvironmentVariable($envVarName12p, 'correct-pass', [System.EnvironmentVariableTarget]::Process)
-    try {
-        $r = Resolve-EnvCredential `
-            -ServerParam '' -DatabaseParam '' -CredentialParam $null `
-            -ServerFromEnvParam '' -UsernameFromEnvParam $envVarName12u -PasswordFromEnvParam $envVarName12p `
-            -ConnectionStringFromEnvParam $envVarName12cs `
-            -TrustServerCertificateParam $false `
-            -Config @{} -BoundParameters @{}
-        Assert-True 'Precedence: *FromEnv creds > ConnStr creds' ($r.Credential.UserName -eq 'correct-user') "got '$($r.Credential.UserName)'"
-    } finally {
-        [System.Environment]::SetEnvironmentVariable($envVarName12cs, $null, [System.EnvironmentVariableTarget]::Process)
-        [System.Environment]::SetEnvironmentVariable($envVarName12u, $null, [System.EnvironmentVariableTarget]::Process)
-        [System.Environment]::SetEnvironmentVariable($envVarName12p, $null, [System.EnvironmentVariableTarget]::Process)
-    }
-
-    # Test 13: Config connection.connectionStringFromEnv is used as fallback
-    $envVarName13 = "TEST_CONNSTR_$(Get-Random)"
-    [System.Environment]::SetEnvironmentVariable($envVarName13, 'Data Source=config-srv;Initial Catalog=config-db;User ID=u;Password=p', [System.EnvironmentVariableTarget]::Process)
-    try {
-        $configWithConnStr = @{ connection = @{ connectionStringFromEnv = $envVarName13 } }
-        $r = Resolve-EnvCredential `
-            -ServerParam '' -DatabaseParam '' -CredentialParam $null `
-            -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
-            -ConnectionStringFromEnvParam '' `
-            -TrustServerCertificateParam $false `
-            -Config $configWithConnStr -BoundParameters @{}
-        Assert-True 'Config connectionStringFromEnv - Server' ($r.Server -eq 'config-srv') "got '$($r.Server)'"
-        Assert-True 'Config connectionStringFromEnv - Database' ($r.Database -eq 'config-db') "got '$($r.Database)'"
-    } finally {
-        [System.Environment]::SetEnvironmentVariable($envVarName13, $null, [System.EnvironmentVariableTarget]::Process)
-    }
-
-    # Test 14: Unset env var throws clear error
-    $unsetVar14 = "TEST_CONNSTR_UNSET_$(Get-Random)"
-    [System.Environment]::SetEnvironmentVariable($unsetVar14, $null, [System.EnvironmentVariableTarget]::Process)
-    try {
-        Resolve-EnvCredential `
-            -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
-            -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
-            -ConnectionStringFromEnvParam $unsetVar14 `
-            -TrustServerCertificateParam $false `
-            -Config @{} -BoundParameters @{ Server = 'srv' } | Out-Null
-        Assert-True 'Unset env var throws' $false 'Expected exception not thrown'
-    } catch {
-        Assert-True 'Unset env var throws descriptive error' ($_.Exception.Message -match 'not set or is empty') "got '$($_.Exception.Message)'"
-    }
-
-    # Test 15: CLI -TrustServerCertificate overrides connection string TrustServerCertificate=true
-    $envVarName15 = "TEST_CONNSTR_$(Get-Random)"
-    [System.Environment]::SetEnvironmentVariable($envVarName15, 'Data Source=srv;Initial Catalog=db;TrustServerCertificate=true', [System.EnvironmentVariableTarget]::Process)
-    try {
-        $r = Resolve-EnvCredential `
-            -ServerParam '' -DatabaseParam '' -CredentialParam $null `
-            -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
-            -ConnectionStringFromEnvParam $envVarName15 `
-            -TrustServerCertificateParam $false `
-            -Config @{} -BoundParameters @{ TrustServerCertificate = $false }
-        Assert-True 'Precedence: CLI TrustServerCertificate:$false > ConnStr TrustServerCertificate=true' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
-    } finally {
-        [System.Environment]::SetEnvironmentVariable($envVarName15, $null, [System.EnvironmentVariableTarget]::Process)
-    }
-
-    # Test 16: Config trustServerCertificate overrides connection string TrustServerCertificate=true
-    $envVarName16 = "TEST_CONNSTR_$(Get-Random)"
-    [System.Environment]::SetEnvironmentVariable($envVarName16, 'Data Source=srv;Initial Catalog=db;TrustServerCertificate=true', [System.EnvironmentVariableTarget]::Process)
-    try {
-        $configWithTrust = @{ connection = @{ trustServerCertificate = $false } }
-        $r = Resolve-EnvCredential `
-            -ServerParam '' -DatabaseParam '' -CredentialParam $null `
-            -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
-            -ConnectionStringFromEnvParam $envVarName16 `
-            -TrustServerCertificateParam $false `
-            -Config $configWithTrust -BoundParameters @{}
-        Assert-True 'Precedence: Config trustServerCertificate:false > ConnStr TrustServerCertificate=true' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
-    } finally {
-        [System.Environment]::SetEnvironmentVariable($envVarName16, $null, [System.EnvironmentVariableTarget]::Process)
-    }
-
-    # Test 17: Connection string with no Server key -> Server remains null/empty
-    $envVarName17 = "TEST_CONNSTR_$(Get-Random)"
-    [System.Environment]::SetEnvironmentVariable($envVarName17, 'Initial Catalog=db;User ID=u;Password=p', [System.EnvironmentVariableTarget]::Process)
-    try {
-        $r = Resolve-EnvCredential `
-            -ServerParam '' -DatabaseParam '' -CredentialParam $null `
-            -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
-            -ConnectionStringFromEnvParam $envVarName17 `
-            -TrustServerCertificateParam $false `
-            -Config @{} -BoundParameters @{}
-        Assert-True 'ConnStr without Server key -> Server remains null/empty' ([string]::IsNullOrEmpty($r.Server)) "got '$($r.Server)'"
-    } finally {
-        [System.Environment]::SetEnvironmentVariable($envVarName17, $null, [System.EnvironmentVariableTarget]::Process)
-    }
-
-    # Summary
-    Write-Host "`n=== Summary ===" -ForegroundColor Cyan
-    Write-Host "Passed: $passed" -ForegroundColor Green
-    Write-Host "Failed: $failed" -ForegroundColor $(if ($failed -gt 0) { 'Red' } else { 'Green' })
-    if ($failed -gt 0) { exit 1 } else { exit 0 }
-
-} finally {
-    Remove-Item $tempFile -ErrorAction SilentlyContinue
 }
+
+Write-Host "`n=== Unit Tests: ConvertFrom-AdoConnectionString ===`n" -ForegroundColor Cyan
+
+# Test 1: Standard SQL Server keys (Data Source, Initial Catalog, User ID, Password)
+$r = ConvertFrom-AdoConnectionString 'Data Source=myserver,1433;Initial Catalog=mydb;User ID=myuser;Password=mypass;TrustServerCertificate=true'
+Assert-True 'Standard keys - Server' ($r.Server -eq 'myserver,1433') "got '$($r.Server)'"
+Assert-True 'Standard keys - Database' ($r.Database -eq 'mydb') "got '$($r.Database)'"
+Assert-True 'Standard keys - Username' ($r.Username -eq 'myuser') "got '$($r.Username)'"
+Assert-True 'Standard keys - Password' ($r.Password -eq 'mypass') "got '$($r.Password)'"
+Assert-True 'Standard keys - TrustServerCertificate=true' ($r.TrustServerCertificate -eq $true) "got '$($r.TrustServerCertificate)'"
+
+# Test 2: Alternate aliases recognized by SqlConnectionStringBuilder (Server, Database)
+$r = ConvertFrom-AdoConnectionString 'Server=myserver2;Database=mydb2;User ID=u2;Password=p2'
+Assert-True 'Alias Server -> DataSource' ($r.Server -eq 'myserver2') "got '$($r.Server)'"
+Assert-True 'Alias Database -> InitialCatalog' ($r.Database -eq 'mydb2') "got '$($r.Database)'"
+Assert-True 'User ID' ($r.Username -eq 'u2') "got '$($r.Username)'"
+Assert-True 'Password' ($r.Password -eq 'p2') "got '$($r.Password)'"
+
+# Test 3: TrustServerCertificate=false
+$r = ConvertFrom-AdoConnectionString 'Data Source=srv;Initial Catalog=db;TrustServerCertificate=false'
+Assert-True 'TrustServerCertificate=false' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
+
+# Test 4: TrustServerCertificate not present -> null
+$r = ConvertFrom-AdoConnectionString 'Data Source=srv;Initial Catalog=db;User ID=u;Password=p'
+Assert-True 'TrustServerCertificate absent -> null' ($null -eq $r.TrustServerCertificate) "got '$($r.TrustServerCertificate)'"
+
+# Test 5: Integrated Security=SSPI (Windows auth)
+$r = ConvertFrom-AdoConnectionString 'Data Source=srv;Initial Catalog=db;Integrated Security=SSPI'
+Assert-True 'Integrated Security=SSPI -> true' ($r.IntegratedSecurity -eq $true) "got '$($r.IntegratedSecurity)'"
+Assert-True 'Integrated Security=SSPI -> no username' ([string]::IsNullOrEmpty($r.Username)) "Username='$($r.Username)'"
+
+# Test 6: Malformed connection string throws descriptive error
+try {
+    ConvertFrom-AdoConnectionString '=bad key=value' | Out-Null
+    Assert-True 'Malformed string throws' $false 'Expected exception not thrown'
+} catch {
+    Assert-True 'Malformed string throws descriptive error' ($_.Exception.Message -match 'Invalid connection string') "got '$($_.Exception.Message)'"
+}
+
+# Test 7: Empty/whitespace string returns all nulls (no throw)
+$r = ConvertFrom-AdoConnectionString '   '
+Assert-True 'Whitespace-only string - Server null' ($null -eq $r.Server) "got '$($r.Server)'"
+Assert-True 'Whitespace-only string - Database null' ($null -eq $r.Database) "got '$($r.Database)'"
+
+# Test 8: Azure SQL connection string
+$r = ConvertFrom-AdoConnectionString 'Server=tcp:myserver.database.windows.net,1433;Initial Catalog=mydb;User ID=admin@myserver;Password=Pass1234!;Encrypt=True;TrustServerCertificate=False;Connection Timeout=30'
+Assert-True 'Azure SQL - Server' ($r.Server -eq 'tcp:myserver.database.windows.net,1433') "got '$($r.Server)'"
+Assert-True 'Azure SQL - Database' ($r.Database -eq 'mydb') "got '$($r.Database)'"
+Assert-True 'Azure SQL - Username' ($r.Username -eq 'admin@myserver') "got '$($r.Username)'"
+Assert-True 'Azure SQL - TrustServerCertificate=False' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
+
+Write-Host "`n=== Unit Tests: Resolve-EnvCredential ConnectionString precedence ===`n" -ForegroundColor Cyan
+
+# Test 9: ConnectionStringFromEnv resolves Server, Database, credentials, and TrustServerCertificate
+$envVarName9 = "TEST_CONNSTR_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVarName9, 'Data Source=testserver;Initial Catalog=testdb;User ID=testuser;Password=testpass;TrustServerCertificate=true', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam '' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVarName9 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{}
+    Assert-True 'ConnStr - Server resolved' ($r.Server -eq 'testserver') "got '$($r.Server)'"
+    Assert-True 'ConnStr - Database resolved' ($r.Database -eq 'testdb') "got '$($r.Database)'"
+    Assert-True 'ConnStr - Credential resolved' ($null -ne $r.Credential) 'Credential was null'
+    Assert-True 'ConnStr - Username in credential' ($r.Credential.UserName -eq 'testuser') "got '$($r.Credential.UserName)'"
+    Assert-True 'ConnStr - TrustServerCertificate from connstr' ($r.TrustServerCertificate -eq $true) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVarName9, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 10: CLI -Server takes precedence over connection string server
+$envVarName10 = "TEST_CONNSTR_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVarName10, 'Data Source=connstr-server;Initial Catalog=connstr-db;User ID=u;Password=p', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam 'cli-server' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVarName10 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'cli-server' }
+    Assert-True 'Precedence: CLI Server > ConnStr Server' ($r.Server -eq 'cli-server') "got '$($r.Server)'"
+    Assert-True 'Precedence: Database from ConnStr (no CLI -Database)' ($r.Database -eq 'connstr-db') "got '$($r.Database)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVarName10, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 11: CLI -Database takes precedence over connection string database
+$envVarName11 = "TEST_CONNSTR_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVarName11, 'Data Source=srv;Initial Catalog=connstr-db;User ID=u;Password=p', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam '' -DatabaseParam 'cli-database' -CredentialParam $null `
+        -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVarName11 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Database = 'cli-database' }
+    Assert-True 'Precedence: CLI Database > ConnStr Database' ($r.Database -eq 'cli-database') "got '$($r.Database)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVarName11, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 12: Individual *FromEnv credentials take precedence over connection string credentials
+$envVarName12cs = "TEST_CONNSTR_$(Get-Random)"
+$envVarName12u  = "TEST_USER_$(Get-Random)"
+$envVarName12p  = "TEST_PASS_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVarName12cs, 'Data Source=srv;Initial Catalog=db;User ID=wrong-user;Password=wrong-pass', [System.EnvironmentVariableTarget]::Process)
+[System.Environment]::SetEnvironmentVariable($envVarName12u, 'correct-user', [System.EnvironmentVariableTarget]::Process)
+[System.Environment]::SetEnvironmentVariable($envVarName12p, 'correct-pass', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam '' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -UsernameFromEnvParam $envVarName12u -PasswordFromEnvParam $envVarName12p `
+        -ConnectionStringFromEnvParam $envVarName12cs `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{}
+    Assert-True 'Precedence: *FromEnv creds > ConnStr creds' ($r.Credential.UserName -eq 'correct-user') "got '$($r.Credential.UserName)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVarName12cs, $null, [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable($envVarName12u, $null, [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable($envVarName12p, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 13: Config connection.connectionStringFromEnv is used as fallback
+$envVarName13 = "TEST_CONNSTR_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVarName13, 'Data Source=config-srv;Initial Catalog=config-db;User ID=u;Password=p', [System.EnvironmentVariableTarget]::Process)
+try {
+    $configWithConnStr = @{ connection = @{ connectionStringFromEnv = $envVarName13 } }
+    $r = Resolve-EnvCredential `
+        -ServerParam '' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config $configWithConnStr -BoundParameters @{}
+    Assert-True 'Config connectionStringFromEnv - Server' ($r.Server -eq 'config-srv') "got '$($r.Server)'"
+    Assert-True 'Config connectionStringFromEnv - Database' ($r.Database -eq 'config-db') "got '$($r.Database)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVarName13, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 14: Unset env var throws clear error
+$unsetVar14 = "TEST_CONNSTR_UNSET_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($unsetVar14, $null, [System.EnvironmentVariableTarget]::Process)
+try {
+    Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $unsetVar14 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv' } | Out-Null
+    Assert-True 'Unset env var throws' $false 'Expected exception not thrown'
+} catch {
+    Assert-True 'Unset env var throws descriptive error' ($_.Exception.Message -match 'not set or is empty') "got '$($_.Exception.Message)'"
+}
+
+# Test 15: CLI -TrustServerCertificate overrides connection string TrustServerCertificate=true
+$envVarName15 = "TEST_CONNSTR_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVarName15, 'Data Source=srv;Initial Catalog=db;TrustServerCertificate=true', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam '' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVarName15 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ TrustServerCertificate = $false }
+    Assert-True 'Precedence: CLI TrustServerCertificate:$false > ConnStr TrustServerCertificate=true' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVarName15, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 16: Config trustServerCertificate overrides connection string TrustServerCertificate=true
+$envVarName16 = "TEST_CONNSTR_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVarName16, 'Data Source=srv;Initial Catalog=db;TrustServerCertificate=true', [System.EnvironmentVariableTarget]::Process)
+try {
+    $configWithTrust = @{ connection = @{ trustServerCertificate = $false } }
+    $r = Resolve-EnvCredential `
+        -ServerParam '' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVarName16 `
+        -TrustServerCertificateParam $false `
+        -Config $configWithTrust -BoundParameters @{}
+    Assert-True 'Precedence: Config trustServerCertificate:false > ConnStr TrustServerCertificate=true' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVarName16, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 17: Connection string with no Server key -> Server remains null/empty
+$envVarName17 = "TEST_CONNSTR_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVarName17, 'Initial Catalog=db;User ID=u;Password=p', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam '' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVarName17 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{}
+    Assert-True 'ConnStr without Server key -> Server remains null/empty' ([string]::IsNullOrEmpty($r.Server)) "got '$($r.Server)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVarName17, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Summary
+Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+Write-Host "Passed: $passed" -ForegroundColor Green
+Write-Host "Failed: $failed" -ForegroundColor $(if ($failed -gt 0) { 'Red' } else { 'Green' })
+if ($failed -gt 0) { exit 1 } else { exit 0 }

--- a/tests/test-common-functions.ps1
+++ b/tests/test-common-functions.ps1
@@ -1,0 +1,356 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Tests shared functions in Common-SqlServerSchema.ps1.
+
+.DESCRIPTION
+    Unit tests for the 4 functions extracted into the common helper library:
+      - Get-EscapedSqlIdentifier
+      - Write-Log
+      - Invoke-WithRetry
+      - Read-ExportMetadata
+
+    Does NOT require SQL Server.
+
+.NOTES
+    Issue: #66 - Extract shared functions into common helper library
+#>
+
+param()
+
+$ErrorActionPreference = 'Stop'
+$scriptDir   = $PSScriptRoot
+$projectRoot = Split-Path $scriptDir -Parent
+
+# Dot-source the common helper library under test
+. (Join-Path $projectRoot 'Common-SqlServerSchema.ps1')
+
+$script:testsPassed = 0
+$script:testsFailed = 0
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Helper
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Write-TestResult {
+  param(
+    [string]$TestName,
+    [bool]$Passed,
+    [string]$Message = ''
+  )
+  if ($Passed) {
+    Write-Host "[SUCCESS] $TestName" -ForegroundColor Green
+    $script:testsPassed++
+  }
+  else {
+    Write-Host "[FAILED]  $TestName" -ForegroundColor Red
+    if ($Message) { Write-Host "  $Message" -ForegroundColor Yellow }
+    $script:testsFailed++
+  }
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Get-EscapedSqlIdentifier Tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Host ''
+Write-Host '═══════════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host 'Get-EscapedSqlIdentifier Tests' -ForegroundColor Cyan
+Write-Host '═══════════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host ''
+
+# 1. Normal name passes through unchanged
+$result = Get-EscapedSqlIdentifier -Name 'Normal_Name'
+Write-TestResult 'Normal name passes through unchanged' ($result -eq 'Normal_Name') "Expected 'Normal_Name', got '$result'"
+
+# 2. Name with ] gets escaped to ]]
+$result = Get-EscapedSqlIdentifier -Name 'Bad]Name'
+Write-TestResult 'Name with ] gets escaped to ]]' ($result -eq 'Bad]]Name') "Expected 'Bad]]Name', got '$result'"
+
+# 3. Name with multiple ] all get escaped
+$result = Get-EscapedSqlIdentifier -Name 'A]B]C'
+Write-TestResult 'Multiple ] all get escaped' ($result -eq 'A]]B]]C') "Expected 'A]]B]]C', got '$result'"
+
+# 4. Whitespace-only string passes through unchanged
+$result = Get-EscapedSqlIdentifier -Name '   '
+Write-TestResult 'Whitespace-only string passes through unchanged' ($result -eq '   ') "Expected '   ', got '$result'"
+
+# 5. Name with [ passes through (only ] needs escaping)
+$result = Get-EscapedSqlIdentifier -Name 'Name[With[Brackets'
+Write-TestResult 'Name with [ passes through unchanged' ($result -eq 'Name[With[Brackets') "Expected 'Name[With[Brackets', got '$result'"
+
+# 6. SQL injection attempt gets escaped
+$result = Get-EscapedSqlIdentifier -Name 'Malicious]; DROP TABLE Users;--'
+Write-TestResult 'SQL injection attempt gets escaped' ($result -eq 'Malicious]]; DROP TABLE Users;--') "Expected 'Malicious]]; DROP TABLE Users;--', got '$result'"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Write-Log Tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Host ''
+Write-Host '═══════════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host 'Write-Log Tests' -ForegroundColor Cyan
+Write-Host '═══════════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host ''
+
+# 7. INFO level writes to output stream
+$script:LogFile = $null
+$output = Write-Log -Message 'Test info message' -Level INFO 6>&1
+Write-TestResult 'INFO level writes to output stream' ($output -eq 'Test info message') "Expected 'Test info message', got '$output'"
+
+# 8. SUCCESS level writes with Write-Host (captured via -6>&1 won't work, test it doesn't throw)
+$script:LogFile = $null
+try {
+  Write-Log -Message 'Test success' -Level SUCCESS *> $null
+  Write-TestResult 'SUCCESS level does not throw' $true
+}
+catch {
+  Write-TestResult 'SUCCESS level does not throw' $false $_.Exception.Message
+}
+
+# 9. WARNING level uses Write-Warning (captured via 3>&1)
+$script:LogFile = $null
+$output = Write-Log -Message 'Test warning' -Level WARNING 3>&1
+Write-TestResult 'WARNING level writes warning' ($null -ne $output -and $output -match 'Test warning') "Expected warning containing 'Test warning', got '$output'"
+
+# 10. ERROR level does not throw (writes to host)
+$script:LogFile = $null
+try {
+  Write-Log -Message 'Test error' -Level ERROR *> $null
+  Write-TestResult 'ERROR level does not throw' $true
+}
+catch {
+  Write-TestResult 'ERROR level does not throw' $false $_.Exception.Message
+}
+
+# 11. Writes to $script:LogFile when set
+$tempLog = Join-Path ([System.IO.Path]::GetTempPath()) "test-write-log-$(Get-Date -Format 'yyyyMMddHHmmss').log"
+try {
+  $script:LogFile = $tempLog
+  Write-Log -Message 'File log test' -Level INFO *> $null
+  $logContent = Get-Content -Path $tempLog -Raw -ErrorAction SilentlyContinue
+  $passed = $logContent -match 'File log test' -and $logContent -match '\[INFO\]'
+  Write-TestResult 'Writes to log file when $script:LogFile is set' $passed "Log content: $logContent"
+}
+finally {
+  $script:LogFile = $null
+  Remove-Item $tempLog -ErrorAction SilentlyContinue
+}
+
+# 12. Skips file write when $script:LogFile is null
+$script:LogFile = $null
+try {
+  Write-Log -Message 'No file test' -Level INFO *> $null
+  Write-TestResult 'Skips file write when $script:LogFile is null' $true
+}
+catch {
+  Write-TestResult 'Skips file write when $script:LogFile is null' $false $_.Exception.Message
+}
+
+# 13. Skips file write when parent directory does not exist
+$script:LogFile = Join-Path ([System.IO.Path]::GetTempPath()) 'nonexistent-dir-xyz/test.log'
+try {
+  Write-Log -Message 'Bad dir test' -Level INFO *> $null
+  $exists = Test-Path $script:LogFile
+  Write-TestResult 'Skips file write when parent directory does not exist' (-not $exists)
+}
+catch {
+  Write-TestResult 'Skips file write when parent directory does not exist' $false $_.Exception.Message
+}
+finally {
+  $script:LogFile = $null
+}
+
+# 14. Timestamp format in log entry
+$tempLog = Join-Path ([System.IO.Path]::GetTempPath()) "test-write-log-ts-$(Get-Date -Format 'yyyyMMddHHmmss').log"
+try {
+  $script:LogFile = $tempLog
+  Write-Log -Message 'Timestamp test' -Level INFO *> $null
+  $logContent = Get-Content -Path $tempLog -Raw -ErrorAction SilentlyContinue
+  $passed = $logContent -match '\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2}\] \[INFO\] Timestamp test'
+  Write-TestResult 'Log entry has correct timestamp format' $passed "Log content: $logContent"
+}
+finally {
+  $script:LogFile = $null
+  Remove-Item $tempLog -ErrorAction SilentlyContinue
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Invoke-WithRetry Tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Host ''
+Write-Host '═══════════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host 'Invoke-WithRetry Tests' -ForegroundColor Cyan
+Write-Host '═══════════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host ''
+
+$script:LogFile = $null
+
+# 15. Successful operation on first attempt
+$result = Invoke-WithRetry -ScriptBlock { 'success' } -OperationName 'Test'
+Write-TestResult 'Successful operation on first attempt' ($result -eq 'success') "Expected 'success', got '$result'"
+
+# 16. Retries on transient failure, succeeds on Nth attempt
+$script:retryCount = 0
+$result = Invoke-WithRetry -ScriptBlock {
+  $script:retryCount++
+  if ($script:retryCount -lt 2) {
+    throw 'connection timed out'
+  }
+  'recovered'
+} -MaxAttempts 3 -InitialDelaySeconds 0 -OperationName 'RetryTest' 3>&1 | Select-Object -Last 1
+# The result might be the string or mixed with warnings; check retryCount
+$passed = $script:retryCount -eq 2
+Write-TestResult 'Retries on transient failure, succeeds on 2nd attempt' $passed "retryCount=$($script:retryCount)"
+
+# 17. Throws after max attempts exhausted
+$script:retryCount = 0
+$threw = $false
+try {
+  Invoke-WithRetry -ScriptBlock {
+    $script:retryCount++
+    throw 'connection timed out'
+  } -MaxAttempts 2 -InitialDelaySeconds 0 -OperationName 'ExhaustTest' *> $null
+}
+catch {
+  $threw = $true
+}
+Write-TestResult 'Throws after max attempts exhausted' ($threw -and $script:retryCount -eq 2) "threw=$threw, retryCount=$($script:retryCount)"
+
+# 18. Respects MaxAttempts parameter
+$script:retryCount = 0
+try {
+  Invoke-WithRetry -ScriptBlock {
+    $script:retryCount++
+    throw 'connection timed out'
+  } -MaxAttempts 1 -InitialDelaySeconds 0 -OperationName 'MaxTest' *> $null
+}
+catch { }
+Write-TestResult 'Respects MaxAttempts=1 (only 1 attempt)' ($script:retryCount -eq 1) "retryCount=$($script:retryCount)"
+
+# 19. Non-transient error throws immediately without retry
+$script:retryCount = 0
+$threw = $false
+try {
+  Invoke-WithRetry -ScriptBlock {
+    $script:retryCount++
+    throw 'invalid syntax error'
+  } -MaxAttempts 3 -InitialDelaySeconds 0 -OperationName 'NonTransientTest' *> $null
+}
+catch {
+  $threw = $true
+}
+Write-TestResult 'Non-transient error throws immediately (no retry)' ($threw -and $script:retryCount -eq 1) "threw=$threw, retryCount=$($script:retryCount)"
+
+# 20. OperationName appears in error messages
+$errorMsg = ''
+try {
+  Invoke-WithRetry -ScriptBlock {
+    throw 'connection timed out'
+  } -MaxAttempts 1 -InitialDelaySeconds 0 -OperationName 'MyOperation' *> $null
+}
+catch {
+  $errorMsg = $_.Exception.Message
+}
+Write-TestResult 'OperationName appears in error context' ($errorMsg -match 'timed out') "Error: $errorMsg"
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Read-ExportMetadata Tests
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Host ''
+Write-Host '═══════════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host 'Read-ExportMetadata Tests' -ForegroundColor Cyan
+Write-Host '═══════════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host ''
+
+# 21. Returns parsed JSON when metadata file exists
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "test-metadata-$(Get-Date -Format 'yyyyMMddHHmmss')"
+New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
+try {
+  $metadata = @{
+    version     = '1.8.0'
+    objectCount = 42
+    exportDate  = '2024-01-15T10:30:00Z'
+  }
+  $metadata | ConvertTo-Json | Set-Content -Path (Join-Path $tempDir '_export_metadata.json') -Encoding UTF8
+
+  $result = Read-ExportMetadata -Path $tempDir
+  $passed = $null -ne $result -and $result.version -eq '1.8.0' -and $result.objectCount -eq 42
+  Write-TestResult 'Returns parsed JSON when metadata file exists' $passed "Result: $($result | ConvertTo-Json -Compress -ErrorAction SilentlyContinue)"
+}
+finally {
+  Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# 22. Returns null when file does not exist
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "test-metadata-missing-$(Get-Date -Format 'yyyyMMddHHmmss')"
+New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
+try {
+  $result = Read-ExportMetadata -Path $tempDir
+  Write-TestResult 'Returns null when file does not exist' ($null -eq $result) "Expected null, got: $result"
+}
+finally {
+  Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# 23. Returns null on invalid JSON (with warning)
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "test-metadata-invalid-$(Get-Date -Format 'yyyyMMddHHmmss')"
+New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
+try {
+  Set-Content -Path (Join-Path $tempDir '_export_metadata.json') -Value 'not valid json {{{' -Encoding UTF8
+
+  $warnings = @()
+  $result = Read-ExportMetadata -Path $tempDir -WarningVariable warnings 3>&1
+  # Filter to get only the return value (not warning messages)
+  $returnValue = $result | Where-Object { $_ -isnot [System.Management.Automation.WarningRecord] }
+  $warningMsgs = $result | Where-Object { $_ -is [System.Management.Automation.WarningRecord] }
+  $passed = ($null -eq $returnValue -or $returnValue.Count -eq 0) -and $warningMsgs.Count -gt 0
+  Write-TestResult 'Returns null on invalid JSON with warning' $passed "returnValue=$returnValue, warnings=$($warningMsgs.Count)"
+}
+finally {
+  Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# 24. Reads correct filename (_export_metadata.json)
+$tempDir = Join-Path ([System.IO.Path]::GetTempPath()) "test-metadata-filename-$(Get-Date -Format 'yyyyMMddHHmmss')"
+New-Item -Path $tempDir -ItemType Directory -Force | Out-Null
+try {
+  # Create a wrong-named file — should NOT be found
+  @{ version = '0.0.0' } | ConvertTo-Json | Set-Content -Path (Join-Path $tempDir 'metadata.json') -Encoding UTF8
+  $result = Read-ExportMetadata -Path $tempDir
+  Write-TestResult 'Ignores non-standard metadata filenames' ($null -eq $result) "Expected null, got: $result"
+
+  # Now create the correct file
+  @{ version = '1.0.0' } | ConvertTo-Json | Set-Content -Path (Join-Path $tempDir '_export_metadata.json') -Encoding UTF8
+  $result = Read-ExportMetadata -Path $tempDir
+  Write-TestResult 'Reads _export_metadata.json specifically' ($null -ne $result -and $result.version -eq '1.0.0') "Result: $result"
+}
+finally {
+  Remove-Item $tempDir -Recurse -Force -ErrorAction SilentlyContinue
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Summary
+# ─────────────────────────────────────────────────────────────────────────────
+
+Write-Host ''
+Write-Host '═══════════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host 'TEST SUMMARY' -ForegroundColor Cyan
+Write-Host '═══════════════════════════════════════════════════════════════' -ForegroundColor Cyan
+Write-Host ''
+
+$total = $script:testsPassed + $script:testsFailed
+Write-Host "Tests Passed: $($script:testsPassed) / $total" -ForegroundColor $(if ($script:testsFailed -eq 0) { 'Green' } else { 'Yellow' })
+Write-Host ''
+
+if ($script:testsFailed -eq 0) {
+  Write-Host '[SUCCESS] ALL COMMON FUNCTION TESTS PASSED!' -ForegroundColor Green
+  exit 0
+}
+else {
+  Write-Host "[FAILED] $($script:testsFailed) test(s) failed" -ForegroundColor Red
+  exit 1
+}

--- a/tests/test-connection-string-from-env.ps1
+++ b/tests/test-connection-string-from-env.ps1
@@ -126,15 +126,16 @@ END
 Write-Host "[INFO] Unit Tests: ConvertFrom-AdoConnectionString parser" -ForegroundColor Cyan
 Write-Host "---------------------------------------------------" -ForegroundColor Cyan
 
-# Load ConvertFrom-AdoConnectionString directly from the production script using brace-counting
+# Load ConvertFrom-AdoConnectionString directly from the production Common helper using brace-counting
 # extraction (same approach used by run-unit-tests.ps1). This ensures tests stay in sync with
 # production code and catch regressions introduced there rather than exercising a duplicate.
-$exportScriptContent = Get-Content $exportScript -Raw
+$commonScript = Join-Path $projectRoot "Common-SqlServerSchema.ps1"
+$exportScriptContent = Get-Content $commonScript -Raw
 function Get-FunctionBlock {
     param([string]$Content, [string]$FunctionName)
     $startPattern = "function $FunctionName "
     $startIndex = $Content.IndexOf($startPattern)
-    if ($startIndex -lt 0) { throw "Function '$FunctionName' not found in Export script" }
+    if ($startIndex -lt 0) { throw "Function '$FunctionName' not found in Common helper script" }
     $depth = 0; $inFunction = $false; $end = $startIndex
     for ($i = $startIndex; $i -lt $Content.Length; $i++) {
         if ($Content[$i] -eq '{') { $depth++; $inFunction = $true }


### PR DESCRIPTION
## Summary
- Foreign keys referencing columns made unique by standalone `CREATE UNIQUE INDEX` (not inline `UNIQUE` constraints) failed during import because indexes (`11_Indexes`) loaded after foreign keys (`10_Tables_ForeignKeys`)
- Swapped folder numbering: `10_Indexes` now loads before `11_Tables_ForeignKeys`
- Updated both Export and Import scripts, folder-to-type mappings, deployment manifest, processing order, docs, and all affected tests

## Test plan
- [x] New unit test `test-index-before-fk.ps1` — 21 assertions validating folder ordering in both scripts
- [x] New integration test case: `dbo.ProductCategories` with standalone unique index referenced by FK on `dbo.Products`
- [x] All existing unit tests pass (`test-import-integrity-report`, `test-validate-only`, `test-config-auto-discovery`, `test-selective-object-types`)
- [x] Full integration test suite passes (13/13 steps including export, dev import, prod import, data verification)

Closes #93