### PR TITLE
feat: import-aware folder ordering with type identifiers (#98)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to Export-SqlServerSchema will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.0] - 2026-03-03
+
+### Added
+
+**Import-aware folder ordering: type identifiers in export metadata and type-based import ordering (#98)**
+- Export metadata (`_export_metadata.json`) now includes `folderOrder` array mapping each numbered folder to a stable type identifier (e.g., `indexes`, `tables_foreignkeys`)
+- Export metadata now includes `exportToolVersion` field tracking the tool version that produced the export
+- Metadata format version bumped from `1.1` to `1.2`
+- Import script maintains its own canonical type-to-order mapping via `Get-CanonicalTypeOrder`, independent of export's folder numbering
+- When processing an export, import reorders folders according to its canonical type ordering using `Get-TypeBasedFolderOrder`
+- For older exports without `folderOrder` metadata, import falls back to name-based type derivation (`Resolve-FolderTypeFromName`)
+- Emits a multi-line `[WARNING]` when import's effective order differs from the export's folder numbering, showing which folders were reordered
+- Added `$script:ExportToolVersion` constant for version tracking
+- Added comprehensive test coverage: `tests/test-import-folder-ordering.ps1` (104 assertions)
+- Full backward compatibility: new import handles old exports (no `folderOrder`), old import ignores new fields
+
 ## [1.8.2] - 2026-02-26
 
 ### Fixed

--- a/Common-SqlServerSchema.ps1
+++ b/Common-SqlServerSchema.ps1
@@ -16,6 +16,7 @@
       - ConvertFrom-AdoConnectionString : Parses ADO.NET connection strings
       - Resolve-EnvCredential        : Resolves credentials from environment variables
       - Resolve-ConfigFile           : Auto-discovers YAML config files
+      - Resolve-FolderTypeFromName   : Derives canonical type ID from numbered folder name
 
     This file has no param() block and no mandatory parameters, making it safe to dot-source.
 
@@ -505,4 +506,71 @@ function Resolve-ConfigFile {
   }
 
   return ''
+}
+
+# ─────────────────────────────────────────────────────────────────────────────
+# Resolve-FolderTypeFromName
+# ─────────────────────────────────────────────────────────────────────────────
+
+function Resolve-FolderTypeFromName {
+  <#
+    .SYNOPSIS
+        Derives a canonical type identifier from a numbered folder name.
+    .DESCRIPTION
+        Fallback for old exports that lack folderOrder in metadata. Strips the
+        leading numeric prefix (e.g., '09_'), then normalizes the remainder
+        (handling PascalCase and separators) to match the canonical type
+        identifiers used by Get-CanonicalTypeOrder.
+    .PARAMETER FolderName
+        The numbered folder name (e.g., '10_Indexes', '09_Tables_PrimaryKey',
+        '02_DatabaseConfiguration').
+    .OUTPUTS
+        Canonical type identifier string (e.g., 'indexes', 'tables_primarykey',
+        'database_configuration').
+  #>
+  param(
+    [Parameter(Mandatory = $true)]
+    [string]$FolderName
+  )
+
+  # Strip the numeric prefix (e.g. '09_')
+  [string]$baseName = ($FolderName -replace '^\d{2}_', '').Trim()
+
+  if ([string]::IsNullOrWhiteSpace($baseName)) {
+    return $baseName
+  }
+
+  # Normalize PascalCase to snake_case:
+  # - Replace hyphens/spaces with underscores
+  # - Insert underscores at camelCase boundaries (e.g. TextSearch -> Text_Search)
+  # - Insert underscores between acronyms and following words (e.g. XMLSchema -> XML_Schema)
+  # - Collapse multiple underscores and lowercase the result
+  # NOTE: Must use [regex]::Replace with 'None' option for case-sensitive matching,
+  # because PowerShell's -replace operator is case-insensitive by default.
+  [string]$normalized = $baseName
+  $normalized = $normalized -replace '[-\s]+', '_'
+  $normalized = [regex]::Replace($normalized, '([a-z0-9])([A-Z])', '$1_$2', 'None')
+  $normalized = [regex]::Replace($normalized, '([A-Z]+)([A-Z][a-z])', '$1_$2', 'None')
+  $normalized = $normalized -replace '_+', '_'
+  $normalized = $normalized.Trim('_').ToLowerInvariant()
+
+  # Fallback mappings for known legacy variants that do not normalize
+  # directly to canonical identifiers via regex alone.
+  [string]$compact = $normalized -replace '_', ''
+  switch ($compact) {
+    'filegroups'            { return 'filegroups' }
+    'databaseconfiguration' { return 'database_configuration' }
+    'partitionfunctions'    { return 'partition_functions' }
+    'partitionschemes'      { return 'partition_schemes' }
+    'xmlschemacollections'  { return 'xml_schema_collections' }
+    'tablesprimarykey'      { return 'tables_primarykey' }
+    'tablesforeignkeys'     { return 'tables_foreignkeys' }
+    'searchpropertylists'   { return 'search_property_lists' }
+    'planguides'            { return 'plan_guides' }
+    'securitypolicies'      { return 'security_policies' }
+    'fulltextsearch'        { return 'fulltext_search' }
+    'externaldata'          { return 'external_data' }
+  }
+
+  return $normalized
 }

--- a/Export-SqlServerSchema.ps1
+++ b/Export-SqlServerSchema.ps1
@@ -3533,10 +3533,13 @@ $script:Config = @{}  # Will be set after config file is loaded
 $script:LastProgressLabel = $null
 $script:CurrentProgressLabel = $null
 
+# Export tool version — keep in sync with CHANGELOG.md
+$script:ExportToolVersion = '1.9.0'
+
 # Export metadata tracking for delta export feature
 # This tracks all objects exported for use in incremental/delta exports
 $script:ExportMetadata = @{
-  Version               = '1.1'
+  Version               = '1.2'
   ExportStartTimeUtc    = $null
   ExportStartTimeServer = $null
   ServerName            = $null
@@ -3800,15 +3803,51 @@ function Save-ExportMetadata {
     }
   }
 
+  # Build folderOrder array — maps each export folder to a stable type identifier
+  $folderOrder = [System.Collections.ArrayList]::new()
+  $folderTypeIdMap = [ordered]@{
+    '00_FileGroups'            = 'filegroups'
+    '01_Security'              = 'security'
+    '02_DatabaseConfiguration' = 'database_configuration'
+    '03_Schemas'               = 'schemas'
+    '04_Sequences'             = 'sequences'
+    '05_PartitionFunctions'    = 'partition_functions'
+    '06_PartitionSchemes'      = 'partition_schemes'
+    '07_Types'                 = 'types'
+    '08_XmlSchemaCollections'  = 'xml_schema_collections'
+    '09_Tables_PrimaryKey'     = 'tables_primarykey'
+    '10_Indexes'               = 'indexes'
+    '11_Tables_ForeignKeys'    = 'tables_foreignkeys'
+    '12_Defaults'              = 'defaults'
+    '13_Rules'                 = 'rules'
+    '14_Programmability'       = 'programmability'
+    '15_Synonyms'              = 'synonyms'
+    '16_FullTextSearch'        = 'fulltext_search'
+    '17_ExternalData'          = 'external_data'
+    '18_SearchPropertyLists'   = 'search_property_lists'
+    '19_PlanGuides'            = 'plan_guides'
+    '20_SecurityPolicies'      = 'security_policies'
+    '21_Data'                  = 'data'
+  }
+
+  foreach ($key in $folderTypeIdMap.Keys) {
+    [void]$folderOrder.Add([ordered]@{
+        folder = $key
+        type   = $folderTypeIdMap[$key]
+      })
+  }
+
   # Build the final metadata object
   $metadata = [ordered]@{
     version               = $script:ExportMetadata.Version
+    exportToolVersion     = $script:ExportToolVersion
     exportStartTimeUtc    = $script:ExportMetadata.ExportStartTimeUtc
     exportStartTimeServer = $script:ExportMetadata.ExportStartTimeServer
     serverName            = $script:ExportMetadata.ServerName
     databaseName          = $script:ExportMetadata.DatabaseName
     groupBy               = $script:ExportMetadata.GroupBy
     includeData           = $script:ExportMetadata.IncludeData
+    folderOrder           = $folderOrder
     objectCount           = $objects.Count
     objects               = $objects
   }

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -3318,6 +3318,148 @@ function Test-ScriptExcluded {
   return $false
 }
 
+function Get-CanonicalTypeOrder {
+  <#
+    .SYNOPSIS
+        Returns the import's canonical type-to-order mapping.
+    .DESCRIPTION
+        Defines the import script's own ordering for folder types, independent
+        of the export's numeric folder prefixes. This allows import to reorder
+        folders from older exports that may have incorrect dependency ordering.
+    .OUTPUTS
+        Ordered hashtable mapping type identifiers to their ordinal position.
+  #>
+  return [ordered]@{
+    'filegroups'            = 0
+    'security'              = 1
+    'database_configuration' = 2
+    'schemas'               = 3
+    'sequences'             = 4
+    'partition_functions'   = 5
+    'partition_schemes'     = 6
+    'types'                 = 7
+    'xml_schema_collections' = 8
+    'tables_primarykey'     = 9
+    'indexes'               = 10
+    'tables_foreignkeys'    = 11
+    'defaults'              = 12
+    'rules'                 = 13
+    'programmability'       = 14
+    'synonyms'              = 15
+    'fulltext_search'       = 16
+    'external_data'         = 17
+    'search_property_lists' = 18
+    'plan_guides'           = 19
+    'security_policies'     = 20
+    'data'                  = 21
+  }
+}
+
+function Resolve-FolderTypeFromName {
+  <#
+    .SYNOPSIS
+        Derives a type identifier from a folder name by stripping the numeric prefix.
+    .DESCRIPTION
+        Fallback for old exports that lack folderOrder in metadata. Strips the
+        leading numeric prefix (e.g., '09_') and lowercases the remainder to
+        produce a type identifier matching the canonical order keys.
+    .PARAMETER FolderName
+        The numbered folder name (e.g., '10_Indexes', '09_Tables_PrimaryKey').
+    .OUTPUTS
+        Type identifier string (e.g., 'indexes', 'tables_primarykey').
+  #>
+  param(
+    [Parameter(Mandatory)]
+    [string]$FolderName
+  )
+
+  $stripped = $FolderName -replace '^\d{2}_', ''
+  return $stripped.ToLowerInvariant()
+}
+
+function Get-TypeBasedFolderOrder {
+  <#
+    .SYNOPSIS
+        Reorders export folders according to import's canonical type ordering.
+    .DESCRIPTION
+        Reads folderOrder from metadata (or falls back to name-based parsing)
+        and returns folder names sorted by import's canonical type ordering.
+        Emits a warning if the effective order differs from the export's numbering.
+    .PARAMETER SourcePath
+        Path to the export directory.
+    .PARAMETER ExportFolders
+        Array of folder names to reorder.
+    .OUTPUTS
+        Array of folder names in import's canonical order.
+  #>
+  param(
+    [Parameter(Mandatory)]
+    [string]$SourcePath,
+
+    [Parameter(Mandatory)]
+    [string[]]$ExportFolders
+  )
+
+  $canonicalOrder = Get-CanonicalTypeOrder
+  $metadata = Read-ExportMetadata -Path $SourcePath
+
+  # Build folder-to-type mapping from metadata or fallback
+  $folderTypeMap = @{}
+  if ($metadata -and $metadata.ContainsKey('folderOrder') -and $metadata.folderOrder) {
+    # New export with folderOrder — use metadata mapping
+    foreach ($entry in $metadata.folderOrder) {
+      $folderTypeMap[$entry.folder] = $entry.type
+    }
+    Write-Verbose "Using folderOrder from metadata (version $($metadata.version))"
+  }
+  else {
+    # Fallback for old exports — derive type from folder name
+    Write-Verbose "No folderOrder in metadata — using name-based fallback"
+    foreach ($folder in $ExportFolders) {
+      $folderTypeMap[$folder] = Resolve-FolderTypeFromName -FolderName $folder
+    }
+  }
+
+  # Sort folders by canonical type order
+  $sortedFolders = @($ExportFolders | Sort-Object {
+      $type = $folderTypeMap[$_]
+      if ($canonicalOrder.Contains($type)) {
+        $canonicalOrder[$type]
+      }
+      else {
+        # Unknown types go to the end, preserving original relative order
+        999
+      }
+    })
+
+  # Detect reordering and emit warning
+  $reordered = $false
+  for ($i = 0; $i -lt [Math]::Min($ExportFolders.Count, $sortedFolders.Count); $i++) {
+    if ($ExportFolders[$i] -ne $sortedFolders[$i]) {
+      $reordered = $true
+      break
+    }
+  }
+
+  if ($reordered) {
+    $warningLines = @("[WARNING] Import order differs from export folder numbering.")
+    $warningLines += "          Import will process folders in the following order:"
+    for ($i = 0; $i -lt $sortedFolders.Count; $i++) {
+      $folder = $sortedFolders[$i]
+      $type = $folderTypeMap[$folder]
+      $exportIdx = [Array]::IndexOf($ExportFolders, $folder)
+      $marker = if ($exportIdx -ne $i) { '   <-- reordered' } else { '' }
+      $num = ($i + 1).ToString().PadLeft(([Math]::Max($sortedFolders.Count, 1)).ToString().Length)
+      $warningLines += "          $num. $folder ($type)$marker"
+    }
+    foreach ($line in $warningLines) {
+      Write-Host $line -ForegroundColor Yellow
+    }
+  }
+
+  return $sortedFolders
+}
+
 function Get-ScriptFiles {
   <#
     .SYNOPSIS
@@ -3458,6 +3600,10 @@ function Get-ScriptFiles {
   else {
     Write-Verbose "Skipping 21_Data (IncludeData=$IncludeData)"
   }
+
+  # Apply type-based reordering using metadata or fallback name parsing
+  # This ensures correct dependency ordering even for older exports with wrong numbering
+  $orderedDirs = @(Get-TypeBasedFolderOrder -SourcePath $Path -ExportFolders $orderedDirs)
 
   # Initialize subfolder paths array (used when filtering granular types like Views, Functions, StoredProcedures)
   $subfolderPaths = @()

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -3355,28 +3355,6 @@ function Get-CanonicalTypeOrder {
   }
 }
 
-function Resolve-FolderTypeFromName {
-  <#
-    .SYNOPSIS
-        Derives a type identifier from a folder name by stripping the numeric prefix.
-    .DESCRIPTION
-        Fallback for old exports that lack folderOrder in metadata. Strips the
-        leading numeric prefix (e.g., '09_') and lowercases the remainder to
-        produce a type identifier matching the canonical order keys.
-    .PARAMETER FolderName
-        The numbered folder name (e.g., '10_Indexes', '09_Tables_PrimaryKey').
-    .OUTPUTS
-        Type identifier string (e.g., 'indexes', 'tables_primarykey').
-  #>
-  param(
-    [Parameter(Mandatory)]
-    [string]$FolderName
-  )
-
-  $stripped = $FolderName -replace '^\d{2}_', ''
-  return $stripped.ToLowerInvariant()
-}
-
 function Get-TypeBasedFolderOrder {
   <#
     .SYNOPSIS
@@ -3428,6 +3406,7 @@ function Get-TypeBasedFolderOrder {
       }
       else {
         # Unknown types go to the end, preserving original relative order
+        Write-Verbose "Folder '$_' has unknown type '$type' — will be sorted to end"
         999
       }
     })

--- a/tests/test-import-folder-ordering.ps1
+++ b/tests/test-import-folder-ordering.ps1
@@ -1,0 +1,375 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Tests import-aware folder ordering (issue #98).
+
+.DESCRIPTION
+    Validates the implementation of type-based import ordering:
+    1. Export metadata v1.2 format (folderOrder, exportToolVersion)
+    2. Canonical type order mapping in import
+    3. Fallback parsing for old exports without folderOrder
+    4. Type-based reordering with warning emission
+    5. Backward compatibility (new import + old metadata)
+
+.NOTES
+    Issue: #98 - Import-aware folder ordering
+#>
+
+param()
+
+$ErrorActionPreference = 'Stop'
+$scriptDir = $PSScriptRoot
+$projectRoot = Split-Path $scriptDir -Parent
+
+# ── Test framework helpers ──────────────────────────────────────────────────
+
+$script:totalTests = 0
+$script:passedTests = 0
+$script:failedTests = 0
+
+function Write-TestResult {
+  param([string]$Name, [bool]$Passed, [string]$Detail = '')
+  $script:totalTests++
+  if ($Passed) {
+    $script:passedTests++
+    Write-Host "  [PASS] $Name" -ForegroundColor Green
+  }
+  else {
+    $script:failedTests++
+    $msg = "  [FAIL] $Name"
+    if ($Detail) { $msg += " - $Detail" }
+    Write-Host $msg -ForegroundColor Red
+  }
+}
+
+function Write-TestInfo {
+  param([string]$Message)
+  Write-Host "  $Message" -ForegroundColor Cyan
+}
+
+# ── Load script content ─────────────────────────────────────────────────────
+
+$exportScript = Join-Path $projectRoot 'Export-SqlServerSchema.ps1'
+$importScript = Join-Path $projectRoot 'Import-SqlServerSchema.ps1'
+$commonScript = Join-Path $projectRoot 'Common-SqlServerSchema.ps1'
+
+$exportContent = Get-Content $exportScript -Raw
+$importContent = Get-Content $importScript -Raw
+
+# ── Test 1: Export metadata version bumped to 1.2 ──────────────────────────
+
+Write-Host "`n=== Test 1: Export metadata version ===" -ForegroundColor Yellow
+
+$hasVersion12 = $exportContent -match "Version\s*=\s*'1\.2'"
+Write-TestResult 'Export: metadata version is 1.2' $hasVersion12
+
+# ── Test 2: Export tool version constant ────────────────────────────────────
+
+Write-Host "`n=== Test 2: Export tool version constant ===" -ForegroundColor Yellow
+
+$hasToolVersion = $exportContent -match '\$script:ExportToolVersion\s*=\s*'''
+Write-TestResult 'Export: $script:ExportToolVersion constant exists' $hasToolVersion
+
+# ── Test 3: Save-ExportMetadata includes folderOrder ────────────────────────
+
+Write-Host "`n=== Test 3: Save-ExportMetadata folderOrder field ===" -ForegroundColor Yellow
+
+# Extract Save-ExportMetadata function
+$saveMetaSection = [regex]::Match($exportContent, 'function Save-ExportMetadata[\s\S]*?(?=\nfunction |\n\z)')
+$saveMetaText = $saveMetaSection.Value
+
+$hasFolderOrderField = $saveMetaText -match 'folderOrder\s*='
+Write-TestResult 'Export: Save-ExportMetadata writes folderOrder' $hasFolderOrderField
+
+$hasExportToolVersionField = $saveMetaText -match 'exportToolVersion\s*='
+Write-TestResult 'Export: Save-ExportMetadata writes exportToolVersion' $hasExportToolVersionField
+
+# ── Test 4: folderOrder contains all 22 folder type mappings ────────────────
+
+Write-Host "`n=== Test 4: folderOrder type ID mappings ===" -ForegroundColor Yellow
+
+$expectedTypes = @(
+  'filegroups', 'security', 'database_configuration', 'schemas', 'sequences',
+  'partition_functions', 'partition_schemes', 'types', 'xml_schema_collections',
+  'tables_primarykey', 'indexes', 'tables_foreignkeys', 'defaults', 'rules',
+  'programmability', 'synonyms', 'fulltext_search', 'external_data',
+  'search_property_lists', 'plan_guides', 'security_policies', 'data'
+)
+
+foreach ($type in $expectedTypes) {
+  $hasType = $saveMetaText -match "'$type'"
+  Write-TestResult "Export: folderOrder contains type '$type'" $hasType
+}
+
+# ── Test 5: folderOrder folder-to-type pairings are correct ─────────────────
+
+Write-Host "`n=== Test 5: folderOrder folder-to-type pairings ===" -ForegroundColor Yellow
+
+$pairings = @{
+  '00_FileGroups'            = 'filegroups'
+  '09_Tables_PrimaryKey'     = 'tables_primarykey'
+  '10_Indexes'               = 'indexes'
+  '11_Tables_ForeignKeys'    = 'tables_foreignkeys'
+  '14_Programmability'       = 'programmability'
+  '21_Data'                  = 'data'
+}
+
+foreach ($folder in $pairings.Keys) {
+  $type = $pairings[$folder]
+  # Check that the folder and type appear in close proximity (same map entry)
+  $hasMapping = $saveMetaText -match "'$folder'\s*=\s*'$type'"
+  Write-TestResult "Export: $folder maps to $type" $hasMapping
+}
+
+# ── Test 6: Import - Get-CanonicalTypeOrder function exists ─────────────────
+
+Write-Host "`n=== Test 6: Import - Get-CanonicalTypeOrder ===" -ForegroundColor Yellow
+
+$hasCanonicalFn = $importContent -match 'function Get-CanonicalTypeOrder'
+Write-TestResult 'Import: Get-CanonicalTypeOrder function exists' $hasCanonicalFn
+
+# Verify it returns all 22 type identifiers
+foreach ($type in $expectedTypes) {
+  $hasType = $importContent -match "'$type'\s*=\s*\d+"
+  Write-TestResult "Import: canonical order contains type '$type'" $hasType
+}
+
+# ── Test 7: Canonical ordering places indexes before foreign keys ───────────
+
+Write-Host "`n=== Test 7: Import canonical order - indexes before FK ===" -ForegroundColor Yellow
+
+# Extract the Get-CanonicalTypeOrder function
+$canonicalSection = [regex]::Match($importContent, 'function Get-CanonicalTypeOrder[\s\S]*?(?=\nfunction )')
+$canonicalText = $canonicalSection.Value
+
+$indexesMatch = [regex]::Match($canonicalText, "'indexes'\s*=\s*(\d+)")
+$fkMatch = [regex]::Match($canonicalText, "'tables_foreignkeys'\s*=\s*(\d+)")
+
+$indexesOrder = if ($indexesMatch.Success) { [int]$indexesMatch.Groups[1].Value } else { -1 }
+$fkOrder = if ($fkMatch.Success) { [int]$fkMatch.Groups[1].Value } else { -1 }
+
+Write-TestResult 'Import: indexes order value found' ($indexesOrder -ge 0)
+Write-TestResult 'Import: tables_foreignkeys order value found' ($fkOrder -ge 0)
+Write-TestResult 'Import: indexes before tables_foreignkeys in canonical order' ($indexesOrder -lt $fkOrder)
+
+# ── Test 8: Resolve-FolderTypeFromName function ─────────────────────────────
+
+Write-Host "`n=== Test 8: Import - Resolve-FolderTypeFromName ===" -ForegroundColor Yellow
+
+$hasResolveFn = $importContent -match 'function Resolve-FolderTypeFromName'
+Write-TestResult 'Import: Resolve-FolderTypeFromName function exists' $hasResolveFn
+
+# Test the function by re-implementing its logic locally
+function Test-ResolveFolderType {
+  param([string]$FolderName)
+  $stripped = $FolderName -replace '^\d{2}_', ''
+  return $stripped.ToLowerInvariant()
+}
+
+$testCases = @{
+  '00_FileGroups'            = 'filegroups'
+  '09_Tables_PrimaryKey'     = 'tables_primarykey'
+  '10_Indexes'               = 'indexes'
+  '11_Tables_ForeignKeys'    = 'tables_foreignkeys'
+  '14_Programmability'       = 'programmability'
+  '21_Data'                  = 'data'
+  '02_DatabaseConfiguration' = 'databaseconfiguration'
+}
+
+foreach ($folder in $testCases.Keys) {
+  $expected = $testCases[$folder]
+  $actual = Test-ResolveFolderType -FolderName $folder
+  Write-TestResult "Resolve: '$folder' -> '$expected'" ($actual -eq $expected)
+}
+
+# ── Test 9: Get-TypeBasedFolderOrder function ───────────────────────────────
+
+Write-Host "`n=== Test 9: Import - Get-TypeBasedFolderOrder ===" -ForegroundColor Yellow
+
+$hasReorderFn = $importContent -match 'function Get-TypeBasedFolderOrder'
+Write-TestResult 'Import: Get-TypeBasedFolderOrder function exists' $hasReorderFn
+
+# Verify it reads metadata
+$hasReadMetadata = [regex]::Match($importContent, 'function Get-TypeBasedFolderOrder[\s\S]*?(?=\nfunction )').Value -match 'Read-ExportMetadata'
+Write-TestResult 'Import: Get-TypeBasedFolderOrder calls Read-ExportMetadata' $hasReadMetadata
+
+# Verify it uses canonical order
+$hasCanonicalUse = [regex]::Match($importContent, 'function Get-TypeBasedFolderOrder[\s\S]*?(?=\nfunction )').Value -match 'Get-CanonicalTypeOrder'
+Write-TestResult 'Import: Get-TypeBasedFolderOrder uses Get-CanonicalTypeOrder' $hasCanonicalUse
+
+# ── Test 10: Get-ScriptFiles uses type-based ordering ───────────────────────
+
+Write-Host "`n=== Test 10: Get-ScriptFiles integration ===" -ForegroundColor Yellow
+
+$scriptFilesSection = [regex]::Match($importContent, 'function Get-ScriptFiles[\s\S]*?(?=\nfunction )')
+$scriptFilesText = $scriptFilesSection.Value
+
+$hasReorderCall = $scriptFilesText -match 'Get-TypeBasedFolderOrder'
+Write-TestResult 'Import: Get-ScriptFiles calls Get-TypeBasedFolderOrder' $hasReorderCall
+
+# ── Test 11: Warning emission logic ─────────────────────────────────────────
+
+Write-Host "`n=== Test 11: Reorder warning emission ===" -ForegroundColor Yellow
+
+$reorderFnSection = [regex]::Match($importContent, 'function Get-TypeBasedFolderOrder[\s\S]*?(?=\nfunction )')
+$reorderFnText = $reorderFnSection.Value
+
+$hasWarningText = $reorderFnText -match '\[WARNING\] Import order differs from export folder numbering'
+Write-TestResult 'Import: warning message text present' $hasWarningText
+
+$hasReorderedMarker = $reorderFnText -match '<-- reordered'
+Write-TestResult 'Import: reordered marker present in warning output' $hasReorderedMarker
+
+# ── Test 12: Fallback handling (no folderOrder in metadata) ─────────────────
+
+Write-Host "`n=== Test 12: Fallback for old exports ===" -ForegroundColor Yellow
+
+$hasFallbackLogic = $reorderFnText -match 'Resolve-FolderTypeFromName'
+Write-TestResult 'Import: fallback calls Resolve-FolderTypeFromName' $hasFallbackLogic
+
+$hasFallbackVerbose = $reorderFnText -match 'No folderOrder in metadata'
+Write-TestResult 'Import: fallback emits verbose message' $hasFallbackVerbose
+
+# ── Test 13: Canonical order is complete (22 entries, 0-21) ─────────────────
+
+Write-Host "`n=== Test 13: Canonical order completeness ===" -ForegroundColor Yellow
+
+$canonicalMatches = [regex]::Matches($canonicalText, "'(\w+)'\s*=\s*(\d+)")
+$ordinals = @{}
+foreach ($m in $canonicalMatches) {
+  $ordinals[$m.Groups[1].Value] = [int]$m.Groups[2].Value
+}
+Write-TestResult 'Import: canonical order has 22 entries' ($ordinals.Count -eq 22)
+
+# Check that ordinal values are 0 through 21 (contiguous)
+$sortedOrdinals = $ordinals.Values | Sort-Object
+$expectedOrdinals = 0..21
+$isContiguous = ($sortedOrdinals -join ',') -eq ($expectedOrdinals -join ',')
+Write-TestResult 'Import: ordinal values are 0..21 (contiguous)' $isContiguous
+
+# ── Test 14: Simulated reordering with old-style numbering ──────────────────
+
+Write-Host "`n=== Test 14: Simulated reorder (old FK-before-Index numbering) ===" -ForegroundColor Yellow
+
+# Simulate old export numbering where FKs were 10_ and Indexes were 11_
+# The canonical order should put indexes before foreign keys
+
+# Re-implement canonical order locally for simulation
+$localCanonical = [ordered]@{
+  'filegroups'            = 0
+  'security'              = 1
+  'database_configuration' = 2
+  'schemas'               = 3
+  'sequences'             = 4
+  'partition_functions'   = 5
+  'partition_schemes'     = 6
+  'types'                 = 7
+  'xml_schema_collections' = 8
+  'tables_primarykey'     = 9
+  'indexes'               = 10
+  'tables_foreignkeys'    = 11
+  'defaults'              = 12
+  'rules'                 = 13
+  'programmability'       = 14
+  'synonyms'              = 15
+  'fulltext_search'       = 16
+  'external_data'         = 17
+  'search_property_lists' = 18
+  'plan_guides'           = 19
+  'security_policies'     = 20
+  'data'                  = 21
+}
+
+# Old-style export folders (wrong order: FK before Indexes)
+$oldFolders = @(
+  '09_Tables_PrimaryKey',
+  '10_Tables_ForeignKeys',  # OLD: FK was 10
+  '11_Indexes'              # OLD: Indexes was 11
+)
+
+# Build folder-to-type mapping using name-based fallback
+$oldTypeMap = @{}
+foreach ($f in $oldFolders) {
+  $stripped = $f -replace '^\d{2}_', ''
+  $oldTypeMap[$f] = $stripped.ToLowerInvariant()
+}
+
+# Sort by canonical order
+$reorderedFolders = @($oldFolders | Sort-Object {
+    $type = $oldTypeMap[$_]
+    if ($localCanonical.Contains($type)) { $localCanonical[$type] } else { 999 }
+  })
+
+Write-TestResult 'Simulation: tables_primarykey first after reorder' ($reorderedFolders[0] -eq '09_Tables_PrimaryKey')
+Write-TestResult 'Simulation: indexes before FK after reorder' ($reorderedFolders[1] -eq '11_Indexes')
+Write-TestResult 'Simulation: FK last after reorder' ($reorderedFolders[2] -eq '10_Tables_ForeignKeys')
+
+# ── Test 15: New export numbering is already correct ────────────────────────
+
+Write-Host "`n=== Test 15: New exports already in correct order ===" -ForegroundColor Yellow
+
+# New-style export folders (correct order)
+$newFolders = @(
+  '09_Tables_PrimaryKey',
+  '10_Indexes',
+  '11_Tables_ForeignKeys'
+)
+
+$newTypeMap = @{}
+foreach ($f in $newFolders) {
+  $stripped = $f -replace '^\d{2}_', ''
+  $newTypeMap[$f] = $stripped.ToLowerInvariant()
+}
+
+$newReordered = @($newFolders | Sort-Object {
+    $type = $newTypeMap[$_]
+    if ($localCanonical.Contains($type)) { $localCanonical[$type] } else { 999 }
+  })
+
+$noChange = ($newReordered[0] -eq $newFolders[0]) -and ($newReordered[1] -eq $newFolders[1]) -and ($newReordered[2] -eq $newFolders[2])
+Write-TestResult 'Simulation: correct-order folders unchanged by reorder' $noChange
+
+# ── Test 16: folderOrder in metadata maps to folder names correctly ─────────
+
+Write-Host "`n=== Test 16: folderOrder metadata folder names ===" -ForegroundColor Yellow
+
+$expectedFolders = @(
+  '00_FileGroups', '01_Security', '02_DatabaseConfiguration', '03_Schemas',
+  '04_Sequences', '05_PartitionFunctions', '06_PartitionSchemes', '07_Types',
+  '08_XmlSchemaCollections', '09_Tables_PrimaryKey', '10_Indexes',
+  '11_Tables_ForeignKeys', '12_Defaults', '13_Rules', '14_Programmability',
+  '15_Synonyms', '16_FullTextSearch', '17_ExternalData', '18_SearchPropertyLists',
+  '19_PlanGuides', '20_SecurityPolicies', '21_Data'
+)
+
+foreach ($folder in $expectedFolders) {
+  $hasFolder = $saveMetaText -match [regex]::Escape("'$folder'")
+  Write-TestResult "Export: folderOrder includes folder '$folder'" $hasFolder
+}
+
+# ── Test 17: Backward compatibility - metadata folderOrder is checked safely ─
+
+Write-Host "`n=== Test 17: Backward compatibility checks ===" -ForegroundColor Yellow
+
+# Verify that Get-TypeBasedFolderOrder handles missing folderOrder
+$hasContainsKeyCheck = $reorderFnText -match "ContainsKey\('folderOrder'\)"
+Write-TestResult 'Import: checks metadata ContainsKey for folderOrder' $hasContainsKeyCheck
+
+# Verify fallback path exists
+$hasFallbackPath = $reorderFnText -match 'No folderOrder in metadata.*fallback'
+Write-TestResult 'Import: fallback path for missing folderOrder' $hasFallbackPath
+
+# ── Summary ──────────────────────────────────────────────────────────────────
+
+Write-Host "`n=== Summary ===" -ForegroundColor Yellow
+Write-Host "  Total: $script:totalTests  Passed: $script:passedTests  Failed: $script:failedTests"
+
+if ($script:failedTests -gt 0) {
+  Write-Host "`n  SOME TESTS FAILED" -ForegroundColor Red
+  exit 1
+}
+else {
+  Write-Host "`n  ALL TESTS PASSED" -ForegroundColor Green
+  exit 0
+}

--- a/tests/test-import-folder-ordering.ps1
+++ b/tests/test-import-folder-ordering.ps1
@@ -57,6 +57,9 @@ $commonScript = Join-Path $projectRoot 'Common-SqlServerSchema.ps1'
 $exportContent = Get-Content $exportScript -Raw
 $importContent = Get-Content $importScript -Raw
 
+# Dot-source Common to get Resolve-FolderTypeFromName for real function testing
+. $commonScript
+
 # ── Test 1: Export metadata version bumped to 1.2 ──────────────────────────
 
 Write-Host "`n=== Test 1: Export metadata version ===" -ForegroundColor Yellow
@@ -155,32 +158,42 @@ Write-TestResult 'Import: indexes before tables_foreignkeys in canonical order' 
 
 # ── Test 8: Resolve-FolderTypeFromName function ─────────────────────────────
 
-Write-Host "`n=== Test 8: Import - Resolve-FolderTypeFromName ===" -ForegroundColor Yellow
+Write-Host "`n=== Test 8: Common - Resolve-FolderTypeFromName ===" -ForegroundColor Yellow
 
-$hasResolveFn = $importContent -match 'function Resolve-FolderTypeFromName'
-Write-TestResult 'Import: Resolve-FolderTypeFromName function exists' $hasResolveFn
+$commonContent = Get-Content $commonScript -Raw
+$hasResolveFn = $commonContent -match 'function Resolve-FolderTypeFromName'
+Write-TestResult 'Common: Resolve-FolderTypeFromName function exists' $hasResolveFn
 
-# Test the function by re-implementing its logic locally
-function Test-ResolveFolderType {
-  param([string]$FolderName)
-  $stripped = $FolderName -replace '^\d{2}_', ''
-  return $stripped.ToLowerInvariant()
-}
-
+# Test the real function (dot-sourced from Common) with all canonical type IDs
 $testCases = @{
   '00_FileGroups'            = 'filegroups'
+  '01_Security'              = 'security'
+  '02_DatabaseConfiguration' = 'database_configuration'
+  '03_Schemas'               = 'schemas'
+  '04_Sequences'             = 'sequences'
+  '05_PartitionFunctions'    = 'partition_functions'
+  '06_PartitionSchemes'      = 'partition_schemes'
+  '07_Types'                 = 'types'
+  '08_XmlSchemaCollections'  = 'xml_schema_collections'
   '09_Tables_PrimaryKey'     = 'tables_primarykey'
   '10_Indexes'               = 'indexes'
   '11_Tables_ForeignKeys'    = 'tables_foreignkeys'
+  '12_Defaults'              = 'defaults'
+  '13_Rules'                 = 'rules'
   '14_Programmability'       = 'programmability'
+  '15_Synonyms'              = 'synonyms'
+  '16_FullTextSearch'        = 'fulltext_search'
+  '17_ExternalData'          = 'external_data'
+  '18_SearchPropertyLists'   = 'search_property_lists'
+  '19_PlanGuides'            = 'plan_guides'
+  '20_SecurityPolicies'      = 'security_policies'
   '21_Data'                  = 'data'
-  '02_DatabaseConfiguration' = 'databaseconfiguration'
 }
 
 foreach ($folder in $testCases.Keys) {
   $expected = $testCases[$folder]
-  $actual = Test-ResolveFolderType -FolderName $folder
-  Write-TestResult "Resolve: '$folder' -> '$expected'" ($actual -eq $expected)
+  $actual = Resolve-FolderTypeFromName -FolderName $folder
+  Write-TestResult "Resolve: '$folder' -> '$expected'" ($actual -eq $expected) $(if ($actual -ne $expected) { "got '$actual'" }  )
 }
 
 # ── Test 9: Get-TypeBasedFolderOrder function ───────────────────────────────
@@ -288,11 +301,10 @@ $oldFolders = @(
   '11_Indexes'              # OLD: Indexes was 11
 )
 
-# Build folder-to-type mapping using name-based fallback
+# Build folder-to-type mapping using real Resolve-FolderTypeFromName
 $oldTypeMap = @{}
 foreach ($f in $oldFolders) {
-  $stripped = $f -replace '^\d{2}_', ''
-  $oldTypeMap[$f] = $stripped.ToLowerInvariant()
+  $oldTypeMap[$f] = Resolve-FolderTypeFromName -FolderName $f
 }
 
 # Sort by canonical order
@@ -318,8 +330,7 @@ $newFolders = @(
 
 $newTypeMap = @{}
 foreach ($f in $newFolders) {
-  $stripped = $f -replace '^\d{2}_', ''
-  $newTypeMap[$f] = $stripped.ToLowerInvariant()
+  $newTypeMap[$f] = Resolve-FolderTypeFromName -FolderName $f
 }
 
 $newReordered = @($newFolders | Sort-Object {


### PR DESCRIPTION
## Summary

Closes #98

Adds type-based import ordering so the import script can reorder folders from older exports that may have incorrect dependency ordering, without requiring the export to be regenerated.

## Changes

### Export (`Export-SqlServerSchema.ps1`)
- Bumped metadata version from `1.1` to `1.2`
- Added `exportToolVersion` field to `_export_metadata.json`
- Added `folderOrder` array mapping each numbered folder to a stable type identifier
- Added `` constant

### Import (`Import-SqlServerSchema.ps1`)
- **`Get-CanonicalTypeOrder`** - import's own type-to-order mapping (22 types, ordinals 0-21)
- **`Resolve-FolderTypeFromName`** - fallback for old exports without `folderOrder` metadata
- **`Get-TypeBasedFolderOrder`** - reorders export folders by canonical type order; emits a multi-line `[WARNING]` when import order differs from export numbering
- **`Get-ScriptFiles`** - now calls `Get-TypeBasedFolderOrder` after building the mode-filtered directory list

### Backward Compatibility
| Scenario | Behavior |
|----------|----------|
| New import + old export (no `folderOrder`) | Falls back to name-based type derivation |
| Old import + new export (has `folderOrder`) | Ignores unknown fields, sorts alphabetically |
| New import + new export | Full type-based ordering with metadata validation |

## Tests

- **104 new assertions** in `tests/test-import-folder-ordering.ps1`
- **All existing tests pass**: index-before-FK (21), common functions (25), integrity report (77)
- **All 13 integration tests pass** (Docker SQL Server)
