### PR TITLE
feat: add Claude Code workflow skills

### DIFF
--- a/.claude/skills/review-feedback/SKILL.md
+++ b/.claude/skills/review-feedback/SKILL.md
@@ -32,22 +32,24 @@ Determine the PR number:
 1. If `$ARGUMENTS` contains a number, use that as the PR number
 2. Otherwise, auto-detect from the current branch:
    ```bash
-   gh pr list --head $(git branch --show-current) --json number,title,url
+   gh pr list --head "$(git branch --show-current)" --json number --jq '.[0].number'
    ```
+   Store the result as the PR number for all subsequent commands.
 3. If no PR is found, ask the user for the PR number
 
 ## Phase 1: Gather Comments
 
-Fetch all review comments on the PR:
+Resolve the repo name dynamically, then fetch all review comments on the PR:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/comments --jq '.[] | {id, path, line, body, user: .user.login, created_at}'
+REPO="$(gh repo view --json nameWithOwner --jq .nameWithOwner)"
+gh api "repos/$REPO/pulls/<PR_NUMBER>/comments" --jq '.[] | {id, path, line, body, user: .user.login, created_at}'
 ```
 
 Also check for top-level PR review summaries:
 
 ```bash
-gh api repos/{owner}/{repo}/pulls/$ARGUMENTS/reviews --jq '.[] | {user: .user.login, state, body}'
+gh api "repos/$REPO/pulls/<PR_NUMBER>/reviews" --jq '.[] | {user: .user.login, state, body}'
 ```
 
 ## Phase 2: Triage — Assess Each Comment
@@ -91,7 +93,7 @@ For each approved fix:
 2. Add or update tests if the comment was about correctness or missing coverage
 3. Verify the fix addresses the specific concern raised
 
-Follow all project conventions (see `copilot-instructions.md`).
+Follow all project conventions (see `.github/copilot-instructions.md`).
 
 ## Phase 5: Run Tests
 
@@ -108,14 +110,15 @@ pwsh -NoProfile -File tests/run-integration-test.ps1
 If integration tests are needed and Docker isn't running:
 
 ```bash
-docker ps --filter "name=sqlserver" --format "{{.Names}} {{.Status}}"
+docker ps --filter "name=sqlserver-test" --format "{{.Names}} {{.Status}}"
 # Start only if not running:
 cd tests && docker-compose up -d
 ```
 
 Copy `tests/.env` from main repo if missing in worktree:
 ```bash
-cp "D:\Export-SqlServerSchema\tests\.env" ./tests/.env
+MAIN_REPO_ROOT="$(git -C "$(git worktree list | head -1 | awk '{print $1}')" rev-parse --show-toplevel)"
+cp "$MAIN_REPO_ROOT/tests/.env" ./tests/.env
 ```
 
 ## Phase 6: Report to User
@@ -135,10 +138,9 @@ Create a commit describing the review fixes:
 
 ```bash
 git add <specific-files>
-git commit -m "fix: address PR review feedback (#$ARGUMENTS)
-
-- Fixed: <brief list of what was fixed>
-- Skipped: <brief note on what was intentionally not changed>"
+git commit -m "fix: address PR review feedback (#<PR_NUMBER>)" \
+    -m "Fixed: <brief list of what was fixed>" \
+    -m "Skipped: <brief note on what was intentionally not changed>"
 ```
 
 Do NOT push unless the user explicitly asks. Do NOT add Co-Authored-By or Claude attribution.

--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -38,18 +38,23 @@ If no issue number is provided, ask the user for one before proceeding.
 
 1. **Read the issue** with `gh issue view $ARGUMENTS` to understand requirements
 2. **Create a worktree** using the `EnterWorktree` tool
-3. **Immediately rename the branch** (worktrees auto-name with `worktree-` prefix):
+3. **Immediately rename the branch** to follow the `feature/` convention:
    ```bash
-   git branch -m worktree-<auto-name> feature/<descriptive-branch-name>
+   git branch -m feature/<descriptive-branch-name>
    ```
-4. **Assign and label the issue**:
+4. **Link the branch to the issue** for traceability:
+   ```bash
+   gh issue develop $ARGUMENTS --branch feature/<descriptive-branch-name>
+   ```
+5. **Assign and label the issue**:
    ```bash
    gh issue edit $ARGUMENTS --add-assignee @me
    gh issue edit $ARGUMENTS --add-label in-progress
    ```
-5. **Copy `tests/.env` from the main repo** (it's gitignored and missing in worktrees):
+6. **Copy `tests/.env` from the main repo** (it's gitignored and missing in worktrees):
    ```bash
-   cp "D:\Export-SqlServerSchema\tests\.env" ./tests/.env
+   MAIN_REPO_ROOT="$(git -C "$(git worktree list | head -1 | awk '{print $1}')" rev-parse --show-toplevel)"
+   cp "$MAIN_REPO_ROOT/tests/.env" ./tests/.env
    ```
 
 ## Phase 1: Plan
@@ -87,20 +92,20 @@ If tests pass before implementation, the tests are not testing the right thing �
 
 ```bash
 # Check if container is already running
-docker ps --filter "name=sqlserver" --format "{{.Names}} {{.Status}}"
+docker ps --filter "name=sqlserver-test" --format "{{.Names}} {{.Status}}"
 
 # Only start if not already running
 cd tests && docker-compose up -d
 
 # Wait for SQL Server to be ready (important!)
-docker exec sqlserver /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'Test@1234' -C -Q "SELECT 1" -b 2>&1
+docker exec sqlserver-test /opt/mssql-tools18/bin/sqlcmd -S localhost -U sa -P 'Test@1234' -C -Q "SELECT 1" -b 2>&1
 ```
 
 NEVER run `docker-compose down` — other sessions may be using the container.
 
 ## Phase 5: Implement
 
-- Write high-quality code following project conventions (see `copilot-instructions.md`)
+- Write high-quality code following project conventions (see `.github/copilot-instructions.md`)
 - No shortcuts, no TODOs, no placeholders — complete implementations only
 - Follow existing patterns in the codebase
 - Use `$script:` scope for cross-function state


### PR DESCRIPTION
## Summary
- Add `/work-issue <number>` skill: end-to-end GitHub issue workflow with worktree setup, TDD, Docker integration tests, self-review, and docs/changelog updates
- Add `/review-feedback [pr-number]` skill: triage PR code review comments, assess validity with user approval gate, implement approved fixes, and report decisions
- Updated `.claude/settings.local.json` (gitignored) with organized permission rules: pre-approve git (except push), file edits, Docker, and pwsh; deny destructive operations

## Details

### `/work-issue` skill
Phases: setup worktree/branch → plan with EnterPlanMode → write tests first (TDD) → validate failure → start Docker if needed → implement → validate success → self code review → update docs/changelog → commit

### `/review-feedback` skill  
Phases: gather PR comments → triage each (valid/priority/action) → present summary table to user → plan fixes after approval → implement → run tests → report what was fixed/skipped → commit

Both skills copy `tests/.env` from main repo (gitignored, missing in worktrees) and never run `docker-compose down`.

## Test plan
- [ ] Invoke `/work-issue` on a test issue and verify all phases execute in order
- [ ] Invoke `/review-feedback` on a PR with comments and verify triage table is presented before implementation
- [ ] Verify `settings.local.json` deny rules block `git push` and `docker-compose down`