### PR TITLE
feat: add DatabaseFromEnv and TrustServerCertificateFromEnv (#86)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **`DatabaseFromEnv` and `TrustServerCertificateFromEnv` parameters (#86)** — Complete the `*FromEnv` pattern for all connection properties:
   - `-DatabaseFromEnv` CLI parameter and `connection.databaseFromEnv` config key resolve database name from an environment variable
   - `-TrustServerCertificateFromEnv` CLI parameter and `connection.trustServerCertificateFromEnv` config key resolve TrustServerCertificate from an environment variable (accepts `true`/`false`/`1`/`0`)
-  - Both follow the same precedence chain: CLI explicit > CLI `*FromEnv` > config `connection.*FromEnv` > connection string > defaults
+  - Both follow the same precedence chain: CLI explicit > CLI `*FromEnv` > CLI `-ConnectionStringFromEnv` > config `connection.*FromEnv` > config `connection.connectionStringFromEnv` > defaults
 
 ## [1.9.0] - 2026-03-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,15 @@ All notable changes to Export-SqlServerSchema will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **`DatabaseFromEnv` and `TrustServerCertificateFromEnv` parameters (#86)** — Complete the `*FromEnv` pattern for all connection properties:
+  - `-DatabaseFromEnv` CLI parameter and `connection.databaseFromEnv` config key resolve database name from an environment variable
+  - `-TrustServerCertificateFromEnv` CLI parameter and `connection.trustServerCertificateFromEnv` config key resolve TrustServerCertificate from an environment variable (accepts `true`/`false`/`1`/`0`)
+  - Both follow the same precedence chain: CLI explicit > CLI `*FromEnv` > config `connection.*FromEnv` > connection string > defaults
+
 ## [1.9.0] - 2026-03-03
 
 ### Added

--- a/Common-SqlServerSchema.ps1
+++ b/Common-SqlServerSchema.ps1
@@ -349,11 +349,13 @@ function Resolve-EnvCredential {
   # --- Resolve TrustServerCertificate ---
   # CLI switch > TrustServerCertificateFromEnv CLI > config connection.trustServerCertificateFromEnv
   # > config connection.trustServerCertificate > config root-level trustServerCertificate > connection string > default (false)
+  # Note: config connection.trustServerCertificateFromEnv is skipped when CLI -ConnectionStringFromEnv
+  # is provided (CLI connection string has higher precedence than config *FromEnv).
   $trustResolvedFromHigherPriority = $BoundParameters.ContainsKey('TrustServerCertificate')
   if (-not $trustResolvedFromHigherPriority) {
-    # Try TrustServerCertificateFromEnv (CLI > config)
+    # Try TrustServerCertificateFromEnv (CLI first, config fallback only if no CLI ConnectionStringFromEnv)
     $trustEnvName = $TrustServerCertificateFromEnvParam
-    if (-not $trustEnvName -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
+    if (-not $trustEnvName -and -not $ConnectionStringFromEnvParam -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
       if ($Config.connection.ContainsKey('trustServerCertificateFromEnv')) {
         $trustEnvName = $Config.connection.trustServerCertificateFromEnv
       }
@@ -416,10 +418,12 @@ function Resolve-EnvCredential {
 
   # --- Resolve Database from individual *FromEnv ---
   # CLI -Database > -DatabaseFromEnv > config connection.databaseFromEnv > connection string
+  # Note: config connection.databaseFromEnv is skipped when CLI -ConnectionStringFromEnv
+  # is provided (CLI connection string has higher precedence than config *FromEnv).
   $databaseResolvedFromHigherPriority = $BoundParameters.ContainsKey('Database') -and -not [string]::IsNullOrWhiteSpace($DatabaseParam)
   if (-not $databaseResolvedFromHigherPriority) {
     $databaseEnvName = $DatabaseFromEnvParam
-    if (-not $databaseEnvName -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
+    if (-not $databaseEnvName -and -not $ConnectionStringFromEnvParam -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
       if ($Config.connection.ContainsKey('databaseFromEnv')) {
         $databaseEnvName = $Config.connection.databaseFromEnv
       }

--- a/Common-SqlServerSchema.ps1
+++ b/Common-SqlServerSchema.ps1
@@ -315,11 +315,12 @@ function Resolve-EnvCredential {
     .DESCRIPTION
         Builds a PSCredential from environment variable names specified via *FromEnv parameters
         or config file connection section. Follows precedence (high to low):
-          1. Explicit -Credential / -Server / -Database command-line parameters
-          2. Individual *FromEnv CLI parameters (-ServerFromEnv, -UsernameFromEnv, -PasswordFromEnv)
+          1. Explicit -Credential / -Server / -Database / -TrustServerCertificate command-line parameters
+          2. Individual *FromEnv CLI parameters (-ServerFromEnv, -DatabaseFromEnv, -UsernameFromEnv, -PasswordFromEnv, -TrustServerCertificateFromEnv)
           3. -ConnectionStringFromEnv CLI parameter (full ADO.NET connection string in env var)
-          4. Config file connection: section equivalents
-          5. Defaults (Windows auth, no overrides)
+          4. Config file connection: section equivalents (serverFromEnv, databaseFromEnv, usernameFromEnv, passwordFromEnv, trustServerCertificateFromEnv, connectionStringFromEnv)
+          5. Config root-level trustServerCertificate
+          6. Defaults (Windows auth, no overrides)
     .OUTPUTS
         Hashtable with resolved Server, Database, Credential, and TrustServerCertificate values.
   #>
@@ -328,9 +329,11 @@ function Resolve-EnvCredential {
     [string]$DatabaseParam,
     [pscredential]$CredentialParam,
     [string]$ServerFromEnvParam,
+    [string]$DatabaseFromEnvParam,
     [string]$UsernameFromEnvParam,
     [string]$PasswordFromEnvParam,
     [string]$ConnectionStringFromEnvParam,
+    [string]$TrustServerCertificateFromEnvParam,
     [bool]$TrustServerCertificateParam,
     [hashtable]$Config,
     [hashtable]$BoundParameters
@@ -344,21 +347,48 @@ function Resolve-EnvCredential {
   }
 
   # --- Resolve TrustServerCertificate ---
-  # CLI switch > config connection section > config root-level > connection string > default (false)
+  # CLI switch > TrustServerCertificateFromEnv CLI > config connection.trustServerCertificateFromEnv
+  # > config connection.trustServerCertificate > config root-level trustServerCertificate > connection string > default (false)
   $trustResolvedFromHigherPriority = $BoundParameters.ContainsKey('TrustServerCertificate')
   if (-not $trustResolvedFromHigherPriority) {
-    $trustResolved = $false
-    if ($Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
-      if ($Config.connection.ContainsKey('trustServerCertificate')) {
-        $result.TrustServerCertificate = [bool]$Config.connection.trustServerCertificate
-        $trustResolved = $true
-        $trustResolvedFromHigherPriority = $true
+    # Try TrustServerCertificateFromEnv (CLI > config)
+    $trustEnvName = $TrustServerCertificateFromEnvParam
+    if (-not $trustEnvName -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
+      if ($Config.connection.ContainsKey('trustServerCertificateFromEnv')) {
+        $trustEnvName = $Config.connection.trustServerCertificateFromEnv
       }
     }
-    # Only fall back to root-level if connection section didn't specify it
-    if (-not $trustResolved -and $Config -and $Config.ContainsKey('trustServerCertificate')) {
-      $result.TrustServerCertificate = [bool]$Config.trustServerCertificate
+
+    if ($trustEnvName) {
+      $trustEnvValue = [System.Environment]::GetEnvironmentVariable($trustEnvName)
+      if ([string]::IsNullOrWhiteSpace($trustEnvValue)) {
+        throw "Environment variable '$trustEnvName' (specified via TrustServerCertificateFromEnv) is not set or is empty."
+      }
+      # Parse as boolean: accept "true"/"false"/"1"/"0"
+      switch ($trustEnvValue.Trim().ToLowerInvariant()) {
+        'true'  { $result.TrustServerCertificate = $true }
+        '1'     { $result.TrustServerCertificate = $true }
+        'false' { $result.TrustServerCertificate = $false }
+        '0'     { $result.TrustServerCertificate = $false }
+        default { throw "Environment variable '$trustEnvName' (specified via TrustServerCertificateFromEnv) has invalid value '$trustEnvValue'. Expected 'true', 'false', '1', or '0'." }
+      }
       $trustResolvedFromHigherPriority = $true
+      Write-Verbose "[ENV] TrustServerCertificate resolved from environment variable '$trustEnvName'"
+    }
+    else {
+      $trustResolved = $false
+      if ($Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
+        if ($Config.connection.ContainsKey('trustServerCertificate')) {
+          $result.TrustServerCertificate = [bool]$Config.connection.trustServerCertificate
+          $trustResolved = $true
+          $trustResolvedFromHigherPriority = $true
+        }
+      }
+      # Only fall back to root-level if connection section didn't specify it
+      if (-not $trustResolved -and $Config -and $Config.ContainsKey('trustServerCertificate')) {
+        $result.TrustServerCertificate = [bool]$Config.trustServerCertificate
+        $trustResolvedFromHigherPriority = $true
+      }
     }
   }
 
@@ -381,6 +411,28 @@ function Resolve-EnvCredential {
       $result.Server = $envValue
       $serverResolvedFromHigherPriority = $true
       Write-Verbose "[ENV] Server resolved from environment variable '$serverEnvName'"
+    }
+  }
+
+  # --- Resolve Database from individual *FromEnv ---
+  # CLI -Database > -DatabaseFromEnv > config connection.databaseFromEnv > connection string
+  $databaseResolvedFromHigherPriority = $BoundParameters.ContainsKey('Database') -and -not [string]::IsNullOrWhiteSpace($DatabaseParam)
+  if (-not $databaseResolvedFromHigherPriority) {
+    $databaseEnvName = $DatabaseFromEnvParam
+    if (-not $databaseEnvName -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
+      if ($Config.connection.ContainsKey('databaseFromEnv')) {
+        $databaseEnvName = $Config.connection.databaseFromEnv
+      }
+    }
+
+    if ($databaseEnvName) {
+      $envValue = [System.Environment]::GetEnvironmentVariable($databaseEnvName)
+      if ([string]::IsNullOrWhiteSpace($envValue)) {
+        throw "Environment variable '$databaseEnvName' (specified via DatabaseFromEnv) is not set or is empty."
+      }
+      $result.Database = $envValue
+      $databaseResolvedFromHigherPriority = $true
+      Write-Verbose "[ENV] Database resolved from environment variable '$databaseEnvName'"
     }
   }
 
@@ -450,7 +502,6 @@ function Resolve-EnvCredential {
       Write-Verbose "[ENV] Server resolved from connection string in environment variable '$connStrEnvName'"
     }
 
-    $databaseResolvedFromHigherPriority = $BoundParameters.ContainsKey('Database') -and -not [string]::IsNullOrWhiteSpace($DatabaseParam)
     if (-not $databaseResolvedFromHigherPriority -and -not [string]::IsNullOrWhiteSpace($parsed.Database)) {
       $result.Database = $parsed.Database
       Write-Verbose "[ENV] Database resolved from connection string in environment variable '$connStrEnvName'"

--- a/Export-SqlServerSchema.ps1
+++ b/Export-SqlServerSchema.ps1
@@ -6759,7 +6759,7 @@ try {
 
   # Validate that Database was resolved from at least one source
   if ([string]::IsNullOrWhiteSpace($Database)) {
-    throw "Database is required. Provide it via -Database, -DatabaseFromEnv, -ConnectionStringFromEnv, or config file connection.databaseFromEnv."
+    throw "Database is required. Provide it via -Database, -DatabaseFromEnv, -ConnectionStringFromEnv, or config file connection.databaseFromEnv / connection.connectionStringFromEnv."
   }
 
   # Store IncludeData in script scope for parallel workers (Build-WorkItems-Data checks this)

--- a/Export-SqlServerSchema.ps1
+++ b/Export-SqlServerSchema.ps1
@@ -21,8 +21,8 @@
     Can also be provided via -ServerFromEnv or config file connection.serverFromEnv.
 
 .PARAMETER Database
-    Database name to script. Can also be provided via -ConnectionStringFromEnv if the connection string
-    contains an Initial Catalog / Database key.
+    Database name to script. Can also be provided via -DatabaseFromEnv, -ConnectionStringFromEnv,
+    or config file connection.databaseFromEnv.
 
 .PARAMETER OutputPath
     Directory where scripts will be exported. Defaults to './DbScripts'
@@ -50,19 +50,30 @@
     Must be paired with -UsernameFromEnv. The password is never written to logs or verbose output.
     Example: -PasswordFromEnv SQLCMD_PASSWORD
 
+.PARAMETER DatabaseFromEnv
+    Name of an environment variable containing the database name. Only used when -Database is
+    not explicitly provided. Example: -DatabaseFromEnv SQLCMD_DATABASE
+
 .PARAMETER ConnectionStringFromEnv
     Name of an environment variable containing a full ADO.NET connection string. This is an
     escape-hatch for environments (Azure App Service SQLCONNSTR_*, GitHub Actions secrets, etc.)
     that provide a single connection string rather than individual components.
     Connection string values are overridden by any explicitly supplied individual parameters.
-    Precedence (high to low): -Server/-Credential > -ServerFromEnv/-UsernameFromEnv/-PasswordFromEnv
+    Precedence (high to low): -Server/-Database/-Credential/-TrustServerCertificate >
+    -ServerFromEnv/-DatabaseFromEnv/-UsernameFromEnv/-PasswordFromEnv/-TrustServerCertificateFromEnv
     > -ConnectionStringFromEnv > config connection: section > defaults.
     Example: -ConnectionStringFromEnv SQLCONNSTR_Default
 
 .PARAMETER TrustServerCertificate
     Trust the SQL Server certificate without validation. Required for containers with self-signed
-    certificates. Can also be set via config file (trustServerCertificate: true or
-    connection.trustServerCertificate: true). WARNING: Disables server identity verification.
+    certificates. Can also be set via -TrustServerCertificateFromEnv, config file
+    (trustServerCertificate: true, connection.trustServerCertificate: true, or
+    connection.trustServerCertificateFromEnv). WARNING: Disables server identity verification.
+
+.PARAMETER TrustServerCertificateFromEnv
+    Name of an environment variable containing a boolean value ('true'/'false'/'1'/'0') for
+    TrustServerCertificate. Only used when -TrustServerCertificate switch is not explicitly provided.
+    Example: -TrustServerCertificateFromEnv SQLCMD_TRUST_CERT
 
 .PARAMETER ConfigFile
     Path to YAML configuration file for advanced export settings. Optional.
@@ -124,7 +135,7 @@ param(
   [Parameter(HelpMessage = 'SQL Server instance name. Can also be provided via -ServerFromEnv or config connection.serverFromEnv')]
   [string]$Server,
 
-  [Parameter(HelpMessage = 'Database name. Can also be provided via -ConnectionStringFromEnv')]
+  [Parameter(HelpMessage = 'Database name. Can also be provided via -DatabaseFromEnv, -ConnectionStringFromEnv, or config connection.databaseFromEnv')]
   [string]$Database,
 
   [Parameter(HelpMessage = 'Output directory for scripts')]
@@ -199,11 +210,17 @@ param(
   [Parameter(HelpMessage = 'Environment variable name containing the password (e.g., -PasswordFromEnv SQLCMD_PASSWORD)')]
   [string]$PasswordFromEnv,
 
+  [Parameter(HelpMessage = 'Environment variable name containing the database name (e.g., -DatabaseFromEnv SQLCMD_DATABASE)')]
+  [string]$DatabaseFromEnv,
+
   [Parameter(HelpMessage = 'Environment variable name containing a full ADO.NET connection string (e.g., -ConnectionStringFromEnv SQLCONNSTR_Default)')]
   [string]$ConnectionStringFromEnv,
 
   [Parameter(HelpMessage = 'Trust the SQL Server certificate without validation. Required for containers with self-signed certificates.')]
   [switch]$TrustServerCertificate,
+
+  [Parameter(HelpMessage = 'Environment variable name containing a boolean for TrustServerCertificate (e.g., -TrustServerCertificateFromEnv SQLCMD_TRUST_CERT)')]
+  [string]$TrustServerCertificateFromEnv,
 
   [Parameter(HelpMessage = 'Validate config, output path, and referenced secrets without connecting to SQL Server. Non-zero exit on errors.')]
   [switch]$ValidateOnly,
@@ -313,8 +330,10 @@ function Invoke-ExportValidation {
     [string]$OutputPath,
     [string]$Server,
     [string]$ServerFromEnv,
+    [string]$DatabaseFromEnv,
     [string]$UsernameFromEnv,
     [string]$PasswordFromEnv,
+    [string]$TrustServerCertificateFromEnv,
     [hashtable]$Config
   )
 
@@ -435,13 +454,37 @@ function Invoke-ExportValidation {
     }
   }
 
+  if ($DatabaseFromEnv) {
+    $val = [System.Environment]::GetEnvironmentVariable($DatabaseFromEnv)
+    if ([string]::IsNullOrWhiteSpace($val)) {
+      [void]$warnings.Add("DatabaseFromEnv '$DatabaseFromEnv' is not set")
+      Write-Host "  [WARN] $DatabaseFromEnv is not set" -ForegroundColor Yellow
+    }
+    else {
+      Write-Host "  [OK] $DatabaseFromEnv is set" -ForegroundColor Green
+    }
+  }
+
+  if ($TrustServerCertificateFromEnv) {
+    $val = [System.Environment]::GetEnvironmentVariable($TrustServerCertificateFromEnv)
+    if ([string]::IsNullOrWhiteSpace($val)) {
+      [void]$warnings.Add("TrustServerCertificateFromEnv '$TrustServerCertificateFromEnv' is not set")
+      Write-Host "  [WARN] $TrustServerCertificateFromEnv is not set" -ForegroundColor Yellow
+    }
+    else {
+      Write-Host "  [OK] $TrustServerCertificateFromEnv is set" -ForegroundColor Green
+    }
+  }
+
   # Check env vars referenced in config file's connection section
   if ($Config -and $Config.connection -and $Config.connection -is [hashtable]) {
     $connSection = $Config.connection
     $envKeyMap = @{
-      serverFromEnv   = 'serverFromEnv'
-      usernameFromEnv = 'usernameFromEnv'
-      passwordFromEnv = 'passwordFromEnv'
+      serverFromEnv                  = 'serverFromEnv'
+      databaseFromEnv                = 'databaseFromEnv'
+      usernameFromEnv                = 'usernameFromEnv'
+      passwordFromEnv                = 'passwordFromEnv'
+      trustServerCertificateFromEnv  = 'trustServerCertificateFromEnv'
     }
     foreach ($cfgKey in $envKeyMap.Keys) {
       $envName = $connSection[$cfgKey]
@@ -458,8 +501,8 @@ function Invoke-ExportValidation {
     }
   }
 
-  if (-not $ServerFromEnv -and -not $UsernameFromEnv -and -not $PasswordFromEnv -and
-      (-not $Config -or -not $Config.connection)) {
+  if (-not $ServerFromEnv -and -not $DatabaseFromEnv -and -not $UsernameFromEnv -and -not $PasswordFromEnv -and
+      -not $TrustServerCertificateFromEnv -and (-not $Config -or -not $Config.connection)) {
     Write-Host "  [INFO] No *FromEnv parameters or config connection section to validate" -ForegroundColor Gray
   }
 
@@ -6676,8 +6719,10 @@ try {
       -OutputPath $OutputPath `
       -Server $Server `
       -ServerFromEnv $ServerFromEnv `
+      -DatabaseFromEnv $DatabaseFromEnv `
       -UsernameFromEnv $UsernameFromEnv `
       -PasswordFromEnv $PasswordFromEnv `
+      -TrustServerCertificateFromEnv $TrustServerCertificateFromEnv `
       -Config $config
     # Invoke-ExportValidation calls exit internally
   }
@@ -6694,9 +6739,11 @@ try {
     -DatabaseParam $Database `
     -CredentialParam $Credential `
     -ServerFromEnvParam $ServerFromEnv `
+    -DatabaseFromEnvParam $DatabaseFromEnv `
     -UsernameFromEnvParam $UsernameFromEnv `
     -PasswordFromEnvParam $PasswordFromEnv `
     -ConnectionStringFromEnvParam $ConnectionStringFromEnv `
+    -TrustServerCertificateFromEnvParam $TrustServerCertificateFromEnv `
     -TrustServerCertificateParam $TrustServerCertificate.IsPresent `
     -Config $config `
     -BoundParameters $PSBoundParameters
@@ -6712,7 +6759,7 @@ try {
 
   # Validate that Database was resolved from at least one source
   if ([string]::IsNullOrWhiteSpace($Database)) {
-    throw "Database is required. Provide it via -Database, -ConnectionStringFromEnv, or config file connection.connectionStringFromEnv."
+    throw "Database is required. Provide it via -Database, -DatabaseFromEnv, -ConnectionStringFromEnv, or config file connection.databaseFromEnv."
   }
 
   # Store IncludeData in script scope for parallel workers (Build-WorkItems-Data checks this)

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -4608,7 +4608,7 @@ try {
 
   # Validate that Database was resolved from at least one source
   if ([string]::IsNullOrWhiteSpace($Database)) {
-    throw "Database is required. Provide it via -Database, -DatabaseFromEnv, -ConnectionStringFromEnv, or config file connection.databaseFromEnv."
+    throw "Database is required. Provide it via -Database, -DatabaseFromEnv, -ConnectionStringFromEnv, or config file connection.databaseFromEnv / connection.connectionStringFromEnv."
   }
 
   # Resolve SourcePath when -UseLatestExport is set

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -15,8 +15,8 @@
 
 .PARAMETER Database
     Target database name. Will be created if -CreateDatabase is specified and it doesn't exist.
-    Can also be provided via -ConnectionStringFromEnv if the connection string contains an
-    Initial Catalog / Database key.
+    Can also be provided via -DatabaseFromEnv, -ConnectionStringFromEnv, or config file
+    connection.databaseFromEnv.
 
 .PARAMETER SourcePath
     Path to the directory containing exported schema files (timestamped folder from Export-SqlServerSchema.ps1).
@@ -38,19 +38,30 @@
     Must be paired with -UsernameFromEnv. The password is never written to logs or verbose output.
     Example: -PasswordFromEnv SQLCMD_PASSWORD
 
+.PARAMETER DatabaseFromEnv
+    Name of an environment variable containing the database name. Only used when -Database is
+    not explicitly provided. Example: -DatabaseFromEnv SQLCMD_DATABASE
+
 .PARAMETER ConnectionStringFromEnv
     Name of an environment variable containing a full ADO.NET connection string. This is an
     escape-hatch for environments (Azure App Service SQLCONNSTR_*, GitHub Actions secrets, etc.)
     that provide a single connection string rather than individual components.
     Connection string values are overridden by any explicitly supplied individual parameters.
-    Precedence (high to low): -Server/-Credential > -ServerFromEnv/-UsernameFromEnv/-PasswordFromEnv
+    Precedence (high to low): -Server/-Database/-Credential/-TrustServerCertificate >
+    -ServerFromEnv/-DatabaseFromEnv/-UsernameFromEnv/-PasswordFromEnv/-TrustServerCertificateFromEnv
     > -ConnectionStringFromEnv > config connection: section > defaults.
     Example: -ConnectionStringFromEnv SQLCONNSTR_Default
 
 .PARAMETER TrustServerCertificate
     Trust the SQL Server certificate without validation. Required for containers with self-signed
-    certificates. Can also be set via config file (trustServerCertificate: true or
-    connection.trustServerCertificate: true). WARNING: Disables server identity verification.
+    certificates. Can also be set via -TrustServerCertificateFromEnv, config file
+    (trustServerCertificate: true, connection.trustServerCertificate: true, or
+    connection.trustServerCertificateFromEnv). WARNING: Disables server identity verification.
+
+.PARAMETER TrustServerCertificateFromEnv
+    Name of an environment variable containing a boolean value ('true'/'false'/'1'/'0') for
+    TrustServerCertificate. Only used when -TrustServerCertificate switch is not explicitly provided.
+    Example: -TrustServerCertificateFromEnv SQLCMD_TRUST_CERT
 
 .PARAMETER ImportMode
     Import mode: 'Dev' (default, schema-only) or 'Prod' (full infrastructure with FileGroups, configs).
@@ -153,7 +164,7 @@ param(
   [Parameter(HelpMessage = 'Target SQL Server instance. Can also be provided via -ServerFromEnv or config connection.serverFromEnv')]
   [string]$Server,
 
-  [Parameter(HelpMessage = 'Target database name. Can also be provided via -ConnectionStringFromEnv')]
+  [Parameter(HelpMessage = 'Target database name. Can also be provided via -DatabaseFromEnv, -ConnectionStringFromEnv, or config connection.databaseFromEnv')]
   [string]$Database,
 
   [Parameter(Mandatory = $true, HelpMessage = 'Path to exported schema scripts')]
@@ -236,11 +247,17 @@ param(
   [Parameter(HelpMessage = 'Environment variable name containing the password (e.g., -PasswordFromEnv SQLCMD_PASSWORD)')]
   [string]$PasswordFromEnv,
 
+  [Parameter(HelpMessage = 'Environment variable name containing the database name (e.g., -DatabaseFromEnv SQLCMD_DATABASE)')]
+  [string]$DatabaseFromEnv,
+
   [Parameter(HelpMessage = 'Environment variable name containing a full ADO.NET connection string (e.g., -ConnectionStringFromEnv SQLCONNSTR_Default)')]
   [string]$ConnectionStringFromEnv,
 
   [Parameter(HelpMessage = 'Trust the SQL Server certificate without validation. Required for containers with self-signed certificates.')]
   [switch]$TrustServerCertificate,
+
+  [Parameter(HelpMessage = 'Environment variable name containing a boolean for TrustServerCertificate (e.g., -TrustServerCertificateFromEnv SQLCMD_TRUST_CERT)')]
+  [string]$TrustServerCertificateFromEnv,
 
   [Parameter(HelpMessage = 'Scan -SourcePath for valid export subfolders and auto-select the most recent one. Can also be set via config file: import.useLatestExport: true')]
   [switch]$UseLatestExport,
@@ -773,8 +790,10 @@ function Invoke-ImportValidation {
     [string]$SourcePath,
     [string]$Server,
     [string]$ServerFromEnv,
+    [string]$DatabaseFromEnv,
     [string]$UsernameFromEnv,
     [string]$PasswordFromEnv,
+    [string]$TrustServerCertificateFromEnv,
     [hashtable]$Config,
     [switch]$StripAlwaysEncrypted
   )
@@ -925,9 +944,31 @@ function Invoke-ImportValidation {
     }
   }
 
+  if ($DatabaseFromEnv) {
+    $val = [System.Environment]::GetEnvironmentVariable($DatabaseFromEnv)
+    if ([string]::IsNullOrWhiteSpace($val)) {
+      [void]$warnings.Add("DatabaseFromEnv '$DatabaseFromEnv' is not set")
+      Write-Host "  [WARN] $DatabaseFromEnv is not set" -ForegroundColor Yellow
+    }
+    else {
+      Write-Host "  [OK] $DatabaseFromEnv is set" -ForegroundColor Green
+    }
+  }
+
+  if ($TrustServerCertificateFromEnv) {
+    $val = [System.Environment]::GetEnvironmentVariable($TrustServerCertificateFromEnv)
+    if ([string]::IsNullOrWhiteSpace($val)) {
+      [void]$warnings.Add("TrustServerCertificateFromEnv '$TrustServerCertificateFromEnv' is not set")
+      Write-Host "  [WARN] $TrustServerCertificateFromEnv is not set" -ForegroundColor Yellow
+    }
+    else {
+      Write-Host "  [OK] $TrustServerCertificateFromEnv is set" -ForegroundColor Green
+    }
+  }
+
   if ($Config -and $Config.connection -and $Config.connection -is [hashtable]) {
     $connSection = $Config.connection
-    foreach ($cfgKey in @('serverFromEnv', 'usernameFromEnv', 'passwordFromEnv')) {
+    foreach ($cfgKey in @('serverFromEnv', 'databaseFromEnv', 'usernameFromEnv', 'passwordFromEnv', 'trustServerCertificateFromEnv')) {
       $envName = $connSection[$cfgKey]
       if ($envName) {
         $val = [System.Environment]::GetEnvironmentVariable($envName)
@@ -942,8 +983,8 @@ function Invoke-ImportValidation {
     }
   }
 
-  if (-not $ServerFromEnv -and -not $UsernameFromEnv -and -not $PasswordFromEnv -and
-      (-not $Config -or -not $Config.connection)) {
+  if (-not $ServerFromEnv -and -not $DatabaseFromEnv -and -not $UsernameFromEnv -and -not $PasswordFromEnv -and
+      -not $TrustServerCertificateFromEnv -and (-not $Config -or -not $Config.connection)) {
     Write-Host "  [INFO] No *FromEnv parameters or config connection section to validate" -ForegroundColor Gray
   }
 
@@ -4499,8 +4540,10 @@ try {
       -SourcePath $SourcePath `
       -Server $Server `
       -ServerFromEnv $ServerFromEnv `
+      -DatabaseFromEnv $DatabaseFromEnv `
       -UsernameFromEnv $UsernameFromEnv `
       -PasswordFromEnv $PasswordFromEnv `
+      -TrustServerCertificateFromEnv $TrustServerCertificateFromEnv `
       -Config $config `
       -StripAlwaysEncrypted:$StripAlwaysEncrypted
     # Invoke-ImportValidation calls exit internally
@@ -4521,9 +4564,11 @@ try {
     -DatabaseParam $Database `
     -CredentialParam $Credential `
     -ServerFromEnvParam $ServerFromEnv `
+    -DatabaseFromEnvParam $DatabaseFromEnv `
     -UsernameFromEnvParam $UsernameFromEnv `
     -PasswordFromEnvParam $PasswordFromEnv `
     -ConnectionStringFromEnvParam $ConnectionStringFromEnv `
+    -TrustServerCertificateFromEnvParam $TrustServerCertificateFromEnv `
     -TrustServerCertificateParam $TrustServerCertificate.IsPresent `
     -Config $config `
     -BoundParameters $PSBoundParameters
@@ -4546,7 +4591,11 @@ try {
     }
   }
   if ($script:ConfigSources.database.source -eq 'default' -and -not [string]::IsNullOrWhiteSpace($Database)) {
-    if ($ConnectionStringFromEnv -or ($config.connection -and $config.connection.connectionStringFromEnv)) {
+    if ($DatabaseFromEnv -or ($config.connection -and $config.connection.databaseFromEnv)) {
+      $envVarName = if ($DatabaseFromEnv) { $DatabaseFromEnv } else { $config.connection.databaseFromEnv }
+      $script:ConfigSources.database = [ordered]@{ value = $Database; source = "envVar:$envVarName" }
+    }
+    elseif ($ConnectionStringFromEnv -or ($config.connection -and $config.connection.connectionStringFromEnv)) {
       $envVarName = if ($ConnectionStringFromEnv) { $ConnectionStringFromEnv } else { $config.connection.connectionStringFromEnv }
       $script:ConfigSources.database = [ordered]@{ value = $Database; source = "envVar:$envVarName" }
     }
@@ -4559,7 +4608,7 @@ try {
 
   # Validate that Database was resolved from at least one source
   if ([string]::IsNullOrWhiteSpace($Database)) {
-    throw "Database is required. Provide it via -Database, -ConnectionStringFromEnv, or config file connection.connectionStringFromEnv."
+    throw "Database is required. Provide it via -Database, -DatabaseFromEnv, -ConnectionStringFromEnv, or config file connection.databaseFromEnv."
   }
 
   # Resolve SourcePath when -UseLatestExport is set

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -209,6 +209,18 @@ connection:
   serverFromEnv: SQLCMD_SERVER
 ```
 
+#### `connection.databaseFromEnv`
+
+- **Type**: String
+- **Default**: none
+- **Description**: Name of an environment variable containing the database name
+- **Precedence**: Only used when `-Database` is not explicitly provided on the command line
+
+```yaml
+connection:
+  databaseFromEnv: SQLCMD_DATABASE
+```
+
 #### `connection.usernameFromEnv`
 
 - **Type**: String
@@ -246,6 +258,18 @@ connection:
   trustServerCertificate: true
 ```
 
+#### `connection.trustServerCertificateFromEnv`
+
+- **Type**: String
+- **Default**: none
+- **Description**: Name of an environment variable containing a boolean value (`true`/`false`/`1`/`0`) for TrustServerCertificate
+- **Precedence**: Only used when `-TrustServerCertificate` switch is not explicitly provided. Takes precedence over `connection.trustServerCertificate` (static boolean) and root-level `trustServerCertificate`.
+
+```yaml
+connection:
+  trustServerCertificateFromEnv: SQLCMD_TRUST_CERT
+```
+
 #### `connection.connectionStringFromEnv`
 
 - **Type**: String
@@ -279,9 +303,10 @@ Using individual env vars:
 ```yaml
 connection:
   serverFromEnv: SQLCMD_SERVER
+  databaseFromEnv: SQLCMD_DATABASE
   usernameFromEnv: SQLCMD_USER
   passwordFromEnv: SQLCMD_PASSWORD
-  trustServerCertificate: true
+  trustServerCertificateFromEnv: SQLCMD_TRUST_CERT
 ```
 
 Using a single connection string env var:
@@ -293,12 +318,13 @@ connection:
 
 #### Credential Precedence
 
-1. **Explicit CLI parameters** (`-Credential`, `-Server`, `-Database`) — highest priority
-2. **CLI individual `*FromEnv` parameters** (`-ServerFromEnv`, `-UsernameFromEnv`, `-PasswordFromEnv`)
+1. **Explicit CLI parameters** (`-Credential`, `-Server`, `-Database`, `-TrustServerCertificate`) — highest priority
+2. **CLI individual `*FromEnv` parameters** (`-ServerFromEnv`, `-DatabaseFromEnv`, `-UsernameFromEnv`, `-PasswordFromEnv`, `-TrustServerCertificateFromEnv`)
 3. **CLI `-ConnectionStringFromEnv`** (full ADO.NET connection string in one env var)
-4. **Config file `connection:` section** — `connection.serverFromEnv`, `connection.usernameFromEnv`,
-   `connection.passwordFromEnv`, `connection.connectionStringFromEnv` (in that order)
-5. **Default** — Windows integrated authentication
+4. **Config file `connection:` section** — `connection.serverFromEnv`, `connection.databaseFromEnv`, `connection.usernameFromEnv`,
+   `connection.passwordFromEnv`, `connection.trustServerCertificateFromEnv`, `connection.connectionStringFromEnv` (in that order)
+5. **Config file static settings** — `connection.trustServerCertificate`, root-level `trustServerCertificate`
+6. **Default** — Windows integrated authentication
 
 #### `targetSqlVersion`
 

--- a/export-import-config.example.yml
+++ b/export-import-config.example.yml
@@ -54,8 +54,10 @@ trustServerCertificate: false
 # Option 1: Individual env vars for each connection component
 # connection:
 #   serverFromEnv: SQLCMD_SERVER        # name of env var holding the server address
+#   databaseFromEnv: SQLCMD_DATABASE    # name of env var holding the database name
 #   usernameFromEnv: SQLCMD_USER        # name of env var holding the username
 #   passwordFromEnv: SQLCMD_PASSWORD    # name of env var holding the password
+#   trustServerCertificateFromEnv: SQLCMD_TRUST_CERT  # name of env var holding true/false/1/0
 #   trustServerCertificate: true        # trust self-signed certs (containers)
 #
 # Option 2: Single full ADO.NET connection string in one env var
@@ -66,10 +68,10 @@ trustServerCertificate: false
 #   connectionStringFromEnv: SQLCONNSTR_Default  # name of env var with full connection string
 #
 # Precedence (high to low):
-#   -Server/-Database/-Credential (CLI) >
-#   -ServerFromEnv/-UsernameFromEnv/-PasswordFromEnv (CLI) >
+#   -Server/-Database/-Credential/-TrustServerCertificate (CLI) >
+#   -ServerFromEnv/-DatabaseFromEnv/-UsernameFromEnv/-PasswordFromEnv/-TrustServerCertificateFromEnv (CLI) >
 #   -ConnectionStringFromEnv (CLI) >
-#   connection.serverFromEnv / connection.usernameFromEnv / connection.passwordFromEnv (config) >
+#   connection.serverFromEnv / connection.databaseFromEnv / connection.usernameFromEnv / connection.passwordFromEnv / connection.trustServerCertificateFromEnv (config) >
 #   connection.connectionStringFromEnv (config) >
 #   defaults
 

--- a/export-import-config.schema.json
+++ b/export-import-config.schema.json
@@ -46,6 +46,10 @@
           "type": "string",
           "description": "Name of the environment variable containing the SQL Server address. Only used when -Server is not explicitly provided. Example: SQLCMD_SERVER"
         },
+        "databaseFromEnv": {
+          "type": "string",
+          "description": "Name of the environment variable containing the database name. Only used when -Database is not explicitly provided. Example: SQLCMD_DATABASE"
+        },
         "usernameFromEnv": {
           "type": "string",
           "description": "Name of the environment variable containing the SQL authentication username. Must be paired with passwordFromEnv. Example: SQLCMD_USER"
@@ -62,6 +66,10 @@
           "type": "boolean",
           "description": "Trust server certificate without validation. Alternative location to the root-level trustServerCertificate setting.",
           "default": false
+        },
+        "trustServerCertificateFromEnv": {
+          "type": "string",
+          "description": "Name of the environment variable containing a boolean value ('true'/'false'/'1'/'0') for TrustServerCertificate. Only used when -TrustServerCertificate is not explicitly provided. Example: SQLCMD_TRUST_CERT"
         }
       },
       "additionalProperties": false

--- a/tests/test-database-trust-from-env.ps1
+++ b/tests/test-database-trust-from-env.ps1
@@ -1,0 +1,329 @@
+#Requires -Version 7.0
+<#
+.SYNOPSIS
+    Unit tests for DatabaseFromEnv and TrustServerCertificateFromEnv parameters
+    in Resolve-EnvCredential. These tests do NOT require a SQL Server connection.
+#>
+
+$ErrorActionPreference = 'Stop'
+$worktreeRoot = Split-Path $PSScriptRoot -Parent
+
+# Load shared functions from Common helper (safe to dot-source — no mandatory params)
+$commonScript = Join-Path $worktreeRoot 'Common-SqlServerSchema.ps1'
+. $commonScript
+
+$passed = 0
+$failed = 0
+
+function Assert-True {
+    param([string]$Name, [bool]$Condition, [string]$Details = '')
+    if ($Condition) {
+        Write-Host "[PASS] $Name" -ForegroundColor Green
+        $script:passed++
+    } else {
+        Write-Host "[FAIL] $Name$(if ($Details) { ": $Details" })" -ForegroundColor Red
+        $script:failed++
+    }
+}
+
+# ═══════════════════════════════════════════════════════════════
+Write-Host "`n=== Unit Tests: DatabaseFromEnv ===`n" -ForegroundColor Cyan
+# ═══════════════════════════════════════════════════════════════
+
+# Test 1: DatabaseFromEnv resolves database from env var
+$envVar1 = "TEST_DB_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar1, 'MyTestDatabase', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam $envVar1 `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv' }
+    Assert-True 'DatabaseFromEnv resolves database' ($r.Database -eq 'MyTestDatabase') "got '$($r.Database)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar1, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 2: CLI -Database takes precedence over DatabaseFromEnv
+$envVar2 = "TEST_DB_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar2, 'EnvDatabase', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'CliDatabase' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam $envVar2 `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv'; Database = 'CliDatabase' }
+    Assert-True 'CLI -Database takes precedence over DatabaseFromEnv' ($r.Database -eq 'CliDatabase') "got '$($r.Database)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar2, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 3: Config connection.databaseFromEnv used as fallback
+$envVar3 = "TEST_DB_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar3, 'ConfigEnvDatabase', [System.EnvironmentVariableTarget]::Process)
+try {
+    $configWithDbEnv = @{ connection = @{ databaseFromEnv = $envVar3 } }
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config $configWithDbEnv -BoundParameters @{ Server = 'srv' }
+    Assert-True 'Config connection.databaseFromEnv resolves database' ($r.Database -eq 'ConfigEnvDatabase') "got '$($r.Database)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar3, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 4: DatabaseFromEnv takes precedence over connection string database
+$envVar4db = "TEST_DB_$(Get-Random)"
+$envVar4cs = "TEST_CS_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar4db, 'EnvDb', [System.EnvironmentVariableTarget]::Process)
+[System.Environment]::SetEnvironmentVariable($envVar4cs, 'Data Source=srv;Initial Catalog=ConnStrDb;User ID=u;Password=p', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam $envVar4db `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVar4cs -TrustServerCertificateFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv' }
+    Assert-True 'DatabaseFromEnv takes precedence over connection string' ($r.Database -eq 'EnvDb') "got '$($r.Database)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar4db, $null, [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable($envVar4cs, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 5: Empty/unset env var for DatabaseFromEnv throws error
+$envVar5 = "TEST_DB_UNSET_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar5, $null, [System.EnvironmentVariableTarget]::Process)
+try {
+    Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam $envVar5 `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv' } | Out-Null
+    Assert-True 'Unset DatabaseFromEnv env var throws' $false 'Expected exception not thrown'
+} catch {
+    Assert-True 'Unset DatabaseFromEnv env var throws descriptive error' ($_.Exception.Message -match 'not set or is empty') "got '$($_.Exception.Message)'"
+}
+
+# Test 6: CLI DatabaseFromEnv takes precedence over config connection.databaseFromEnv
+$envVar6cli = "TEST_DB_CLI_$(Get-Random)"
+$envVar6cfg = "TEST_DB_CFG_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar6cli, 'CliEnvDb', [System.EnvironmentVariableTarget]::Process)
+[System.Environment]::SetEnvironmentVariable($envVar6cfg, 'CfgEnvDb', [System.EnvironmentVariableTarget]::Process)
+try {
+    $configWithDbEnv = @{ connection = @{ databaseFromEnv = $envVar6cfg } }
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam $envVar6cli `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config $configWithDbEnv -BoundParameters @{ Server = 'srv' }
+    Assert-True 'CLI DatabaseFromEnv takes precedence over config databaseFromEnv' ($r.Database -eq 'CliEnvDb') "got '$($r.Database)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar6cli, $null, [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable($envVar6cfg, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# ═══════════════════════════════════════════════════════════════
+Write-Host "`n=== Unit Tests: TrustServerCertificateFromEnv ===`n" -ForegroundColor Cyan
+# ═══════════════════════════════════════════════════════════════
+
+# Test 7: TrustServerCertificateFromEnv resolves "true"
+$envVar7 = "TEST_TRUST_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar7, 'true', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam $envVar7 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv' }
+    Assert-True 'TrustServerCertificateFromEnv "true" -> $true' ($r.TrustServerCertificate -eq $true) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar7, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 8: TrustServerCertificateFromEnv resolves "false"
+$envVar8 = "TEST_TRUST_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar8, 'false', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam $envVar8 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv' }
+    Assert-True 'TrustServerCertificateFromEnv "false" -> $false' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar8, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 9: TrustServerCertificateFromEnv resolves "1"
+$envVar9 = "TEST_TRUST_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar9, '1', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam $envVar9 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv' }
+    Assert-True 'TrustServerCertificateFromEnv "1" -> $true' ($r.TrustServerCertificate -eq $true) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar9, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 10: TrustServerCertificateFromEnv resolves "0"
+$envVar10 = "TEST_TRUST_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar10, '0', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam $envVar10 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv' }
+    Assert-True 'TrustServerCertificateFromEnv "0" -> $false' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar10, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 11: CLI -TrustServerCertificate switch takes precedence over TrustServerCertificateFromEnv
+$envVar11 = "TEST_TRUST_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar11, 'true', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam $envVar11 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv'; TrustServerCertificate = $false }
+    Assert-True 'CLI TrustServerCertificate takes precedence over TrustServerCertificateFromEnv' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar11, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 12: Config connection.trustServerCertificateFromEnv used as fallback
+$envVar12 = "TEST_TRUST_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar12, 'true', [System.EnvironmentVariableTarget]::Process)
+try {
+    $configWithTrustEnv = @{ connection = @{ trustServerCertificateFromEnv = $envVar12 } }
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config $configWithTrustEnv -BoundParameters @{ Server = 'srv' }
+    Assert-True 'Config connection.trustServerCertificateFromEnv resolves trust' ($r.TrustServerCertificate -eq $true) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar12, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 13: TrustServerCertificateFromEnv takes precedence over connection string
+$envVar13trust = "TEST_TRUST_$(Get-Random)"
+$envVar13cs = "TEST_CS_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar13trust, 'false', [System.EnvironmentVariableTarget]::Process)
+[System.Environment]::SetEnvironmentVariable($envVar13cs, 'Data Source=srv;Initial Catalog=db;TrustServerCertificate=true', [System.EnvironmentVariableTarget]::Process)
+try {
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVar13cs -TrustServerCertificateFromEnvParam $envVar13trust `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv' }
+    Assert-True 'TrustServerCertificateFromEnv takes precedence over connection string' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar13trust, $null, [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable($envVar13cs, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 14: Empty/unset env var for TrustServerCertificateFromEnv throws error
+$envVar14 = "TEST_TRUST_UNSET_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar14, $null, [System.EnvironmentVariableTarget]::Process)
+try {
+    Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam $envVar14 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv' } | Out-Null
+    Assert-True 'Unset TrustServerCertificateFromEnv env var throws' $false 'Expected exception not thrown'
+} catch {
+    Assert-True 'Unset TrustServerCertificateFromEnv env var throws descriptive error' ($_.Exception.Message -match 'not set or is empty') "got '$($_.Exception.Message)'"
+}
+
+# Test 15: Invalid value for TrustServerCertificateFromEnv throws error
+$envVar15 = "TEST_TRUST_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar15, 'yes', [System.EnvironmentVariableTarget]::Process)
+try {
+    Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam $envVar15 `
+        -TrustServerCertificateParam $false `
+        -Config @{} -BoundParameters @{ Server = 'srv' } | Out-Null
+    Assert-True 'Invalid TrustServerCertificateFromEnv value throws' $false 'Expected exception not thrown'
+} catch {
+    Assert-True 'Invalid TrustServerCertificateFromEnv value throws descriptive error' ($_.Exception.Message -match 'invalid value') "got '$($_.Exception.Message)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar15, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 16: TrustServerCertificateFromEnv takes precedence over config connection.trustServerCertificate (static)
+$envVar16 = "TEST_TRUST_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar16, 'false', [System.EnvironmentVariableTarget]::Process)
+try {
+    $configWithStaticTrust = @{ connection = @{ trustServerCertificate = $true } }
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam $envVar16 `
+        -TrustServerCertificateParam $false `
+        -Config $configWithStaticTrust -BoundParameters @{ Server = 'srv' }
+    Assert-True 'TrustServerCertificateFromEnv takes precedence over config static trustServerCertificate' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar16, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 17: TrustServerCertificateFromEnv takes precedence over root-level trustServerCertificate
+$envVar17 = "TEST_TRUST_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar17, 'false', [System.EnvironmentVariableTarget]::Process)
+try {
+    $configWithRootTrust = @{ trustServerCertificate = $true }
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam '' -TrustServerCertificateFromEnvParam $envVar17 `
+        -TrustServerCertificateParam $false `
+        -Config $configWithRootTrust -BoundParameters @{ Server = 'srv' }
+    Assert-True 'TrustServerCertificateFromEnv takes precedence over root-level trustServerCertificate' ($r.TrustServerCertificate -eq $false) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar17, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Summary
+Write-Host "`n=== Summary ===" -ForegroundColor Cyan
+Write-Host "Passed: $passed" -ForegroundColor Green
+Write-Host "Failed: $failed" -ForegroundColor $(if ($failed -gt 0) { 'Red' } else { 'Green' })
+if ($failed -gt 0) { exit 1 } else { exit 0 }

--- a/tests/test-database-trust-from-env.ps1
+++ b/tests/test-database-trust-from-env.ps1
@@ -322,6 +322,50 @@ try {
     [System.Environment]::SetEnvironmentVariable($envVar17, $null, [System.EnvironmentVariableTarget]::Process)
 }
 
+# ═══════════════════════════════════════════════════════════════
+Write-Host "`n=== Unit Tests: CLI ConnectionStringFromEnv > config *FromEnv precedence ===`n" -ForegroundColor Cyan
+# ═══════════════════════════════════════════════════════════════
+
+# Test 18: CLI -ConnectionStringFromEnv takes precedence over config connection.databaseFromEnv
+$envVar18db = "TEST_DB_CFG_$(Get-Random)"
+$envVar18cs = "TEST_CS_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar18db, 'ConfigDb', [System.EnvironmentVariableTarget]::Process)
+[System.Environment]::SetEnvironmentVariable($envVar18cs, 'Data Source=srv;Initial Catalog=ConnStrDb;User ID=u;Password=p', [System.EnvironmentVariableTarget]::Process)
+try {
+    $configWithDbEnv = @{ connection = @{ databaseFromEnv = $envVar18db } }
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam '' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVar18cs -TrustServerCertificateFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config $configWithDbEnv -BoundParameters @{ Server = 'srv' }
+    Assert-True 'CLI ConnectionStringFromEnv takes precedence over config databaseFromEnv' ($r.Database -eq 'ConnStrDb') "got '$($r.Database)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar18db, $null, [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable($envVar18cs, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 19: CLI -ConnectionStringFromEnv takes precedence over config connection.trustServerCertificateFromEnv
+$envVar19trust = "TEST_TRUST_CFG_$(Get-Random)"
+$envVar19cs = "TEST_CS_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar19trust, 'false', [System.EnvironmentVariableTarget]::Process)
+[System.Environment]::SetEnvironmentVariable($envVar19cs, 'Data Source=srv;Initial Catalog=db;TrustServerCertificate=true', [System.EnvironmentVariableTarget]::Process)
+try {
+    $configWithTrustEnv = @{ connection = @{ trustServerCertificateFromEnv = $envVar19trust } }
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVar19cs -TrustServerCertificateFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config $configWithTrustEnv -BoundParameters @{ Server = 'srv' }
+    Assert-True 'CLI ConnectionStringFromEnv takes precedence over config trustServerCertificateFromEnv' ($r.TrustServerCertificate -eq $true) "got '$($r.TrustServerCertificate)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar19trust, $null, [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable($envVar19cs, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
 # Summary
 Write-Host "`n=== Summary ===" -ForegroundColor Cyan
 Write-Host "Passed: $passed" -ForegroundColor Green


### PR DESCRIPTION
## Summary
- Adds `-DatabaseFromEnv` CLI parameter and `connection.databaseFromEnv` config key to resolve the database name from an environment variable
- Adds `-TrustServerCertificateFromEnv` CLI parameter and `connection.trustServerCertificateFromEnv` config key to resolve TrustServerCertificate from an environment variable (accepts `true`/`false`/`1`/`0`)
- Completes the `*FromEnv` pattern so all connection properties (Server, Database, Username, Password, TrustServerCertificate) can be sourced from environment variables

## Precedence (high to low)
1. Explicit CLI: `-Server`, `-Database`, `-Credential`, `-TrustServerCertificate`
2. Individual `*FromEnv` CLI: `-ServerFromEnv`, `-DatabaseFromEnv`, `-UsernameFromEnv`/`-PasswordFromEnv`, `-TrustServerCertificateFromEnv`
3. `-ConnectionStringFromEnv` CLI
4. Config `connection:` section equivalents
5. Config root-level `trustServerCertificate`
6. Defaults

## Files changed
- `Common-SqlServerSchema.ps1` — `Resolve-EnvCredential` updated with new params and resolution blocks
- `Export-SqlServerSchema.ps1` — new params, help text, validation, error messages
- `Import-SqlServerSchema.ps1` — same as Export, plus `ConfigSources` tracking for `databaseFromEnv`
- `export-import-config.schema.json` — new `databaseFromEnv` and `trustServerCertificateFromEnv` properties
- `export-import-config.example.yml` — updated examples and precedence docs
- `docs/CONFIG_REFERENCE.md` — documentation for new config keys
- `CHANGELOG.md` — `[Unreleased]` entry
- `tests/test-database-trust-from-env.ps1` — 17 new unit tests

## Test plan
- [x] New unit tests: 17/17 passed (`tests/test-database-trust-from-env.ps1`)
- [x] Existing unit tests: 35/35 passed (`tests/run-unit-tests.ps1`)
- [x] Env credentials tests: 18/18 passed (`tests/test-env-credentials.ps1`)
- [x] Connection string tests: 20/20 passed (`tests/test-connection-string-from-env.ps1`)
- [ ] No breaking changes — existing `trustServerCertificate` (root and connection section) still works

Closes #86