### PR TITLE
refactor: move git workflow instructions into skills

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -2,21 +2,8 @@
 
 See `.github/copilot-instructions.md` for full project context, architecture, code conventions, and critical patterns. All instructions there apply here.
 
-## Git workflow
+## Workflow skills
 
-### Worktrees and branch naming
-`EnterWorktree` auto-names the branch with a `worktree-` prefix. Always rename it immediately after the worktree is created, before doing any other work:
+Use the `/work-issue` skill when starting work on a GitHub issue — it handles worktree setup, branch naming, issue linking, TDD, and the full development lifecycle.
 
-```bash
-git branch -m worktree-feature/<name> feature/<name>
-```
-
-Feature branches must follow the format `feature/<branch-name>`.
-
-### Starting work on a GitHub issue
-When beginning work on a GitHub issue, always do all of the following before writing any code:
-1. **Assign** the issue to yourself (`gh issue edit <number> --add-assignee @me`)
-2. **Label** it as in-progress (`gh issue edit <number> --add-label in-progress`)
-3. **Link the branch** to the issue after creating it (`gh issue develop <number> --branch feature/<branch-name>` or manually via `gh api ...`)
-
-These steps ensure visibility into active work and traceability from issue to branch to PR.
+Use the `/review-feedback` skill to triage and address PR code review comments.

--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -38,18 +38,18 @@ If no issue number is provided, ask the user for one before proceeding.
 
 1. **Read the issue** with `gh issue view $ARGUMENTS` to understand requirements
 2. **Create a worktree** using the `EnterWorktree` tool
-3. **Immediately rename the branch** to follow the `feature/` convention:
+3. **Immediately rename the branch** — `EnterWorktree` auto-names with a `worktree-` prefix that must be renamed before doing any other work. Feature branches must follow the `feature/<name>` format:
    ```bash
-   git branch -m feature/<descriptive-branch-name>
+   git branch -m worktree-<auto-name> feature/<descriptive-branch-name>
    ```
-4. **Link the branch to the issue** for traceability:
-   ```bash
-   gh issue develop $ARGUMENTS --branch feature/<descriptive-branch-name>
-   ```
-5. **Assign and label the issue**:
+4. **Assign and label the issue**:
    ```bash
    gh issue edit $ARGUMENTS --add-assignee @me
    gh issue edit $ARGUMENTS --add-label in-progress
+   ```
+5. **Link the branch to the issue** for traceability:
+   ```bash
+   gh issue develop $ARGUMENTS --branch feature/<descriptive-branch-name>
    ```
 6. **Copy `tests/.env` from the main repo** (it's gitignored and missing in worktrees):
    ```bash

--- a/.claude/skills/work-issue/SKILL.md
+++ b/.claude/skills/work-issue/SKILL.md
@@ -40,7 +40,7 @@ If no issue number is provided, ask the user for one before proceeding.
 2. **Create a worktree** using the `EnterWorktree` tool
 3. **Immediately rename the branch** — `EnterWorktree` auto-names with a `worktree-` prefix that must be renamed before doing any other work. Feature branches must follow the `feature/<name>` format:
    ```bash
-   git branch -m worktree-<auto-name> feature/<descriptive-branch-name>
+   git branch -m feature/<descriptive-branch-name>
    ```
 4. **Assign and label the issue**:
    ```bash


### PR DESCRIPTION
## Summary
- Moved worktree naming and issue setup instructions from `.claude/CLAUDE.md` into the `work-issue` skill where they're actionable
- Replaced CLAUDE.md's git workflow section with a concise pointer to `/work-issue` and `/review-feedback` skills
- Enhanced the `work-issue` skill Phase 0 to explicitly document the `EnterWorktree` auto-naming behavior (`worktree-` prefix)

## Test plan
- [ ] Verify `/work-issue` skill triggers correctly and Phase 0 instructions are clear
- [ ] Verify `/review-feedback` skill still triggers correctly
- [ ] Confirm CLAUDE.md loads without issues