### PR TITLE
fix: config serverFromEnv and credential *FromEnv no longer override CLI -ConnectionStringFromEnv (#105)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Config `serverFromEnv`/`usernameFromEnv`/`passwordFromEnv` no longer override CLI `-ConnectionStringFromEnv` (#105)** — Added `-not $ConnectionStringFromEnvParam` guards to the config fallback paths for server and credential resolution in `Resolve-EnvCredential`, matching the fix already applied for `databaseFromEnv` and `trustServerCertificateFromEnv` in #102.
+
 ### Added
 
 - **`DatabaseFromEnv` and `TrustServerCertificateFromEnv` parameters (#86)** — Complete the `*FromEnv` pattern for all connection properties:

--- a/Common-SqlServerSchema.ps1
+++ b/Common-SqlServerSchema.ps1
@@ -396,10 +396,12 @@ function Resolve-EnvCredential {
 
   # --- Resolve Server from individual *FromEnv ---
   # CLI -Server > -ServerFromEnv > config connection.serverFromEnv
+  # Note: config connection.serverFromEnv is skipped when CLI -ConnectionStringFromEnv
+  # is provided (CLI connection string has higher precedence than config *FromEnv).
   $serverResolvedFromHigherPriority = $BoundParameters.ContainsKey('Server') -and -not [string]::IsNullOrWhiteSpace($ServerParam)
   if (-not $serverResolvedFromHigherPriority) {
     $serverEnvName = $ServerFromEnvParam
-    if (-not $serverEnvName -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
+    if (-not $serverEnvName -and -not $ConnectionStringFromEnvParam -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
       if ($Config.connection.ContainsKey('serverFromEnv')) {
         $serverEnvName = $Config.connection.serverFromEnv
       }
@@ -442,13 +444,16 @@ function Resolve-EnvCredential {
 
   # --- Resolve Credential from individual *FromEnv ---
   # CLI -Credential > *FromEnv params > config connection.*FromEnv
+  # Note: config connection.*FromEnv is skipped when CLI -ConnectionStringFromEnv
+  # is provided (CLI connection string has higher precedence than config *FromEnv).
   $credResolvedFromHigherPriority = $BoundParameters.ContainsKey('Credential') -and $null -ne $CredentialParam
   if (-not $credResolvedFromHigherPriority) {
     $usernameEnvName = $UsernameFromEnvParam
     $passwordEnvName = $PasswordFromEnvParam
 
-    # Fall back to config file connection section
-    if ($Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
+    # Fall back to config file connection section (skip if CLI ConnectionStringFromEnv is provided,
+    # since CLI connection string has higher precedence than config *FromEnv)
+    if (-not $ConnectionStringFromEnvParam -and $Config -and $Config.ContainsKey('connection') -and $Config.connection -is [System.Collections.IDictionary]) {
       if (-not $usernameEnvName -and $Config.connection.ContainsKey('usernameFromEnv')) {
         $usernameEnvName = $Config.connection.usernameFromEnv
       }

--- a/tests/test-database-trust-from-env.ps1
+++ b/tests/test-database-trust-from-env.ps1
@@ -366,6 +366,49 @@ try {
     [System.Environment]::SetEnvironmentVariable($envVar19cs, $null, [System.EnvironmentVariableTarget]::Process)
 }
 
+# Test 20: CLI -ConnectionStringFromEnv takes precedence over config connection.serverFromEnv
+$envVar20srv = "TEST_SRV_CFG_$(Get-Random)"
+$envVar20cs = "TEST_CS_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar20srv, 'ConfigServer', [System.EnvironmentVariableTarget]::Process)
+[System.Environment]::SetEnvironmentVariable($envVar20cs, 'Data Source=ConnStrServer;Initial Catalog=db;User ID=u;Password=p', [System.EnvironmentVariableTarget]::Process)
+try {
+    $configWithSrvEnv = @{ connection = @{ serverFromEnv = $envVar20srv } }
+    $r = Resolve-EnvCredential `
+        -ServerParam '' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVar20cs -TrustServerCertificateFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config $configWithSrvEnv -BoundParameters @{ Database = 'db' }
+    Assert-True 'CLI ConnectionStringFromEnv takes precedence over config serverFromEnv' ($r.Server -eq 'ConnStrServer') "got '$($r.Server)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar20srv, $null, [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable($envVar20cs, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
+# Test 21: CLI -ConnectionStringFromEnv takes precedence over config connection.usernameFromEnv/passwordFromEnv
+$envVar21user = "TEST_USER_CFG_$(Get-Random)"
+$envVar21pass = "TEST_PASS_CFG_$(Get-Random)"
+$envVar21cs = "TEST_CS_$(Get-Random)"
+[System.Environment]::SetEnvironmentVariable($envVar21user, 'ConfigUser', [System.EnvironmentVariableTarget]::Process)
+[System.Environment]::SetEnvironmentVariable($envVar21pass, 'ConfigPass', [System.EnvironmentVariableTarget]::Process)
+[System.Environment]::SetEnvironmentVariable($envVar21cs, 'Data Source=srv;Initial Catalog=db;User ID=ConnStrUser;Password=ConnStrPass', [System.EnvironmentVariableTarget]::Process)
+try {
+    $configWithCredEnv = @{ connection = @{ usernameFromEnv = $envVar21user; passwordFromEnv = $envVar21pass } }
+    $r = Resolve-EnvCredential `
+        -ServerParam 'srv' -DatabaseParam 'db' -CredentialParam $null `
+        -ServerFromEnvParam '' -DatabaseFromEnvParam '' `
+        -UsernameFromEnvParam '' -PasswordFromEnvParam '' `
+        -ConnectionStringFromEnvParam $envVar21cs -TrustServerCertificateFromEnvParam '' `
+        -TrustServerCertificateParam $false `
+        -Config $configWithCredEnv -BoundParameters @{ Server = 'srv'; Database = 'db' }
+    Assert-True 'CLI ConnectionStringFromEnv takes precedence over config usernameFromEnv/passwordFromEnv' ($r.Credential.UserName -eq 'ConnStrUser') "got '$($r.Credential.UserName)'"
+} finally {
+    [System.Environment]::SetEnvironmentVariable($envVar21user, $null, [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable($envVar21pass, $null, [System.EnvironmentVariableTarget]::Process)
+    [System.Environment]::SetEnvironmentVariable($envVar21cs, $null, [System.EnvironmentVariableTarget]::Process)
+}
+
 # Summary
 Write-Host "`n=== Summary ===" -ForegroundColor Cyan
 Write-Host "Passed: $passed" -ForegroundColor Green


### PR DESCRIPTION
## Summary

- Added `-not $ConnectionStringFromEnvParam` guards to config fallback paths for **server** and **credential** resolution in `Resolve-EnvCredential`, so CLI `-ConnectionStringFromEnv` (tier 3) correctly takes precedence over config `connection.serverFromEnv`, `connection.usernameFromEnv`, and `connection.passwordFromEnv` (tier 4)
- Matches the fix already applied for `databaseFromEnv` and `trustServerCertificateFromEnv` in #102
- Added 2 unit tests (Tests 20-21) verifying CLI `-ConnectionStringFromEnv` beats config `serverFromEnv` and `usernameFromEnv`/`passwordFromEnv`

Closes #105

## Test plan

- [x] New unit tests pass (21/21 in `test-database-trust-from-env.ps1`)
- [x] All existing unit tests pass (35/35 in `run-unit-tests.ps1`)
- [x] Integration tests pass (13/13 in `run-integration-test.ps1`)