### PR TITLE
test: add integrity report errorChain tests (#92)

### DIFF
--- a/tests/test-error-handling.ps1
+++ b/tests/test-error-handling.ps1
@@ -455,12 +455,60 @@ if ($chainErrorLogs.Count -gt 0) {
     $hasErrorChainSection = $chainLogContent -match "Error Chain:"
     Write-TestResult -TestName "Error log has Error Chain section" -Passed $hasErrorChainSection `
         -Message "Error log should have an 'Error Chain:' section with formatted messages"
+
+    # Test 6d: Integrity report JSON contains structured errorChain array
+    $chainReportFiles = Get-ChildItem -Path $chainExportedDir.FullName -Filter "import-report-*.json" -ErrorAction SilentlyContinue
+    if ($chainReportFiles.Count -gt 0) {
+        $chainReport = Get-Content $chainReportFiles[0].FullName -Raw | ConvertFrom-Json
+        $chainFailed = $chainReport.failedObjects | Where-Object { $_.name -match 'fn_ChainTest' }
+        if ($chainFailed) {
+            # errorMessage should be the clean root cause (Message: line, not Error NNN:)
+            $hasCleanRootCause = $chainFailed.errorMessage -match "Invalid object name" -and $chainFailed.errorMessage -notmatch "^Error \d+:"
+            Write-TestResult -TestName "Integrity report errorMessage is clean root cause" -Passed $hasCleanRootCause `
+                -Message "errorMessage should be the innermost exception message without 'Error NNN:' prefix"
+
+            # errorChain should be an array with type and message fields
+            $hasErrorChainArray = $chainFailed.errorChain -is [array] -and $chainFailed.errorChain.Count -gt 0
+            Write-TestResult -TestName "Integrity report has errorChain array" -Passed $hasErrorChainArray `
+                -Message "failedObjects should include errorChain array with structured exception data"
+
+            if ($hasErrorChainArray) {
+                $hasTypeAndMessage = ($chainFailed.errorChain[0].PSObject.Properties.Name -contains 'type') -and
+                                     ($chainFailed.errorChain[0].PSObject.Properties.Name -contains 'message')
+                Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $hasTypeAndMessage `
+                    -Message "Each errorChain entry should have 'type' and 'message' fields"
+            } else {
+                Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $false `
+                    -Message "errorChain array was empty or missing"
+            }
+        } else {
+            Write-TestResult -TestName "Integrity report errorMessage is clean root cause" -Passed $false `
+                -Message "fn_ChainTest not found in failedObjects"
+            Write-TestResult -TestName "Integrity report has errorChain array" -Passed $false `
+                -Message "fn_ChainTest not found in failedObjects"
+            Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $false `
+                -Message "fn_ChainTest not found in failedObjects"
+        }
+    } else {
+        Write-TestResult -TestName "Integrity report errorMessage is clean root cause" -Passed $false `
+            -Message "No integrity report JSON was created for chain test"
+        Write-TestResult -TestName "Integrity report has errorChain array" -Passed $false `
+            -Message "No integrity report JSON was created for chain test"
+        Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $false `
+            -Message "No integrity report JSON was created for chain test"
+    }
 } else {
     Write-TestResult -TestName "Error log contains inner exception message" -Passed $false `
         -Message "No error log was created for chain test"
     Write-TestResult -TestName "Error chain uses arrow (→) format" -Passed $false `
         -Message "No error log was created for chain test"
     Write-TestResult -TestName "Error log has Error Chain section" -Passed $false `
+        -Message "No error log was created for chain test"
+    Write-TestResult -TestName "Integrity report errorMessage is clean root cause" -Passed $false `
+        -Message "No error log was created for chain test"
+    Write-TestResult -TestName "Integrity report has errorChain array" -Passed $false `
+        -Message "No error log was created for chain test"
+    Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $false `
         -Message "No error log was created for chain test"
 }
 

--- a/tests/test-error-handling.ps1
+++ b/tests/test-error-handling.ps1
@@ -475,10 +475,16 @@ if ($chainErrorLogs.Count -gt 0) {
                 -Message "failedObjects should include errorChain array with structured exception data"
 
             if ($hasErrorChainArray) {
-                $hasTypeAndMessage = ($chainFailed.errorChain[0].PSObject.Properties.Name -contains 'type') -and
-                                     ($chainFailed.errorChain[0].PSObject.Properties.Name -contains 'message')
-                Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $hasTypeAndMessage `
-                    -Message "Each errorChain entry should have 'type' and 'message' fields"
+                $allValid = $true
+                foreach ($entry in $chainFailed.errorChain) {
+                    if (-not (($entry.PSObject.Properties.Name -contains 'type') -and
+                              ($entry.PSObject.Properties.Name -contains 'message'))) {
+                        $allValid = $false
+                        break
+                    }
+                }
+                Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $allValid `
+                    -Message "Every errorChain entry should have 'type' and 'message' fields"
             } else {
                 Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $false `
                     -Message "errorChain array was empty or missing"

--- a/tests/test-error-handling.ps1
+++ b/tests/test-error-handling.ps1
@@ -457,10 +457,12 @@ if ($chainErrorLogs.Count -gt 0) {
         -Message "Error log should have an 'Error Chain:' section with formatted messages"
 
     # Test 6d: Integrity report JSON contains structured errorChain array
-    $chainReportFiles = Get-ChildItem -Path $chainExportedDir.FullName -Filter "import-report-*.json" -ErrorAction SilentlyContinue
-    if ($chainReportFiles.Count -gt 0) {
-        $chainReport = Get-Content $chainReportFiles[0].FullName -Raw | ConvertFrom-Json
-        $chainFailed = $chainReport.failedObjects | Where-Object { $_.name -match 'fn_ChainTest' }
+    $chainReportFile = Get-ChildItem -Path $chainExportedDir.FullName -Filter "import-report-*.json" -ErrorAction SilentlyContinue |
+        Sort-Object -Property LastWriteTime, Name -Descending |
+        Select-Object -First 1
+    if ($chainReportFile) {
+        $chainReport = Get-Content -Path $chainReportFile.FullName -Raw | ConvertFrom-Json
+        $chainFailed = $chainReport.failedObjects | Where-Object { $_.name -match 'fn_ChainTest' } | Select-Object -First 1
         if ($chainFailed) {
             # errorMessage should be the clean root cause (Message: line, not Error NNN:)
             $hasCleanRootCause = $chainFailed.errorMessage -match "Invalid object name" -and $chainFailed.errorMessage -notmatch "^Error \d+:"

--- a/tests/test-error-handling.ps1
+++ b/tests/test-error-handling.ps1
@@ -94,6 +94,13 @@ function Invoke-SqlCommand {
     return $result
 }
 
+function Write-ErrorChainTestFailures {
+    param([string]$Reason)
+    Write-TestResult -TestName "Integrity report errorMessage is clean root cause" -Passed $false -Message $Reason
+    Write-TestResult -TestName "Integrity report has errorChain array" -Passed $false -Message $Reason
+    Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $false -Message $Reason
+}
+
 function Drop-TestDatabase {
     param([string]$DbName)
     try {
@@ -461,49 +468,47 @@ if ($chainErrorLogs.Count -gt 0) {
         Sort-Object -Property LastWriteTime, Name -Descending |
         Select-Object -First 1
     if ($chainReportFile) {
-        $chainReport = Get-Content -Path $chainReportFile.FullName -Raw | ConvertFrom-Json
-        $chainFailed = $chainReport.failedObjects | Where-Object { $_.name -match 'fn_ChainTest' } | Select-Object -First 1
-        if ($chainFailed) {
-            # errorMessage should be the clean root cause (Message: line, not Error NNN:)
-            $hasCleanRootCause = $chainFailed.errorMessage -match "Invalid object name" -and $chainFailed.errorMessage -notmatch "^Error \d+:"
-            Write-TestResult -TestName "Integrity report errorMessage is clean root cause" -Passed $hasCleanRootCause `
-                -Message "errorMessage should be the innermost exception message without 'Error NNN:' prefix"
+        $chainReport = $null
+        try {
+            $chainReport = Get-Content -Path $chainReportFile.FullName -Raw -ErrorAction Stop | ConvertFrom-Json -ErrorAction Stop
+        } catch {
+            Write-ErrorChainTestFailures "Failed to parse integrity report JSON: $($_.Exception.Message)"
+        }
 
-            # errorChain should be an array with type and message fields
-            $hasErrorChainArray = $chainFailed.errorChain -is [array] -and $chainFailed.errorChain.Count -gt 0
-            Write-TestResult -TestName "Integrity report has errorChain array" -Passed $hasErrorChainArray `
-                -Message "failedObjects should include errorChain array with structured exception data"
+        if ($chainReport) {
+            $chainFailed = $chainReport.failedObjects | Where-Object { $_.name -match 'fn_ChainTest' } | Select-Object -First 1
+            if ($chainFailed) {
+                # errorMessage should be the clean root cause (Message: line, not Error NNN:)
+                $hasCleanRootCause = $chainFailed.errorMessage -match "Invalid object name" -and $chainFailed.errorMessage -notmatch "^Error \d+:"
+                Write-TestResult -TestName "Integrity report errorMessage is clean root cause" -Passed $hasCleanRootCause `
+                    -Message "errorMessage should be the innermost exception message without 'Error NNN:' prefix"
 
-            if ($hasErrorChainArray) {
-                $allValid = $true
-                foreach ($entry in $chainFailed.errorChain) {
-                    if (-not (($entry.PSObject.Properties.Name -contains 'type') -and
-                              ($entry.PSObject.Properties.Name -contains 'message'))) {
-                        $allValid = $false
-                        break
+                # errorChain should be an array with type and message fields
+                $hasErrorChainArray = $chainFailed.errorChain -is [array] -and $chainFailed.errorChain.Count -gt 0
+                Write-TestResult -TestName "Integrity report has errorChain array" -Passed $hasErrorChainArray `
+                    -Message "failedObjects should include errorChain array with structured exception data"
+
+                if ($hasErrorChainArray) {
+                    $allValid = $true
+                    foreach ($entry in $chainFailed.errorChain) {
+                        if (-not (($entry.PSObject.Properties.Name -contains 'type') -and
+                                  ($entry.PSObject.Properties.Name -contains 'message'))) {
+                            $allValid = $false
+                            break
+                        }
                     }
+                    Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $allValid `
+                        -Message "Every errorChain entry should have 'type' and 'message' fields"
+                } else {
+                    Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $false `
+                        -Message "errorChain array was empty or missing"
                 }
-                Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $allValid `
-                    -Message "Every errorChain entry should have 'type' and 'message' fields"
             } else {
-                Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $false `
-                    -Message "errorChain array was empty or missing"
+                Write-ErrorChainTestFailures "fn_ChainTest not found in failedObjects"
             }
-        } else {
-            Write-TestResult -TestName "Integrity report errorMessage is clean root cause" -Passed $false `
-                -Message "fn_ChainTest not found in failedObjects"
-            Write-TestResult -TestName "Integrity report has errorChain array" -Passed $false `
-                -Message "fn_ChainTest not found in failedObjects"
-            Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $false `
-                -Message "fn_ChainTest not found in failedObjects"
         }
     } else {
-        Write-TestResult -TestName "Integrity report errorMessage is clean root cause" -Passed $false `
-            -Message "No integrity report JSON was created for chain test"
-        Write-TestResult -TestName "Integrity report has errorChain array" -Passed $false `
-            -Message "No integrity report JSON was created for chain test"
-        Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $false `
-            -Message "No integrity report JSON was created for chain test"
+        Write-ErrorChainTestFailures "No integrity report JSON was created for chain test"
     }
 } else {
     Write-TestResult -TestName "Error log contains inner exception message" -Passed $false `
@@ -512,12 +517,7 @@ if ($chainErrorLogs.Count -gt 0) {
         -Message "No error log was created for chain test"
     Write-TestResult -TestName "Error log has Error Chain section" -Passed $false `
         -Message "No error log was created for chain test"
-    Write-TestResult -TestName "Integrity report errorMessage is clean root cause" -Passed $false `
-        -Message "No error log was created for chain test"
-    Write-TestResult -TestName "Integrity report has errorChain array" -Passed $false `
-        -Message "No error log was created for chain test"
-    Write-TestResult -TestName "errorChain entries have type and message fields" -Passed $false `
-        -Message "No error log was created for chain test"
+    Write-ErrorChainTestFailures "No error log was created for chain test"
 }
 
 Drop-TestDatabase -DbName $targetDb6


### PR DESCRIPTION
## Summary
- Add 3 test cases to `test-error-handling.ps1` verifying the new `errorChain` field in the integrity report JSON:
  - `errorMessage` is the clean root cause (no `Error NNN:` prefix)
  - `errorChain` is a non-empty array
  - Each `errorChain` entry has `type` and `message` fields
- Also adds null checks for export directory setup in tests 6 and 7

Follow-up to #104 which was squash-merged without this test commit.

## Test plan
- [x] `test-error-handling.ps1` — 23/23 passed
- [x] `run-integration-test.ps1` — 13/13 passed