### PR TITLE
fix: schema-bound folder detection uses substring matching (#112)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **Schema-bound folder detection uses prefix matching instead of substring matching (#112)** — `Test-SchemaExcluded` and `Test-ObjectExcluded` now strip numeric prefixes and use `-like` with trailing wildcard instead of `-match` (regex substring matching). This fixes false positives where folders like `DatabaseConfiguration` incorrectly matched the `Data` entry. Also added missing schema-bound folders: `Types`, `XmlSchemaCollections`, `Defaults`, `Rules`.
+
 - **Config `serverFromEnv`/`usernameFromEnv`/`passwordFromEnv` no longer override CLI `-ConnectionStringFromEnv` (#105)** — Added `-not $ConnectionStringFromEnvParam` guards to the config fallback paths for server and credential resolution in `Resolve-EnvCredential`, matching the fix already applied for `databaseFromEnv` and `trustServerCertificateFromEnv` in #102.
 
 - **Improved error reporting with full exception chains (#92)** — SQL errors during import now display all nested exception messages instead of only the outermost wrapper (e.g., "One or more errors occurred."):

--- a/Import-Helpers.ps1
+++ b/Import-Helpers.ps1
@@ -63,17 +63,23 @@ function Test-SchemaExcluded {
     'Triggers',         # Matches 04_Triggers (nested under 14_Programmability)
     'Synonyms',         # Matches 15_Synonyms
     'Sequences',        # Matches 04_Sequences
-    '_Data'             # Matches 21_Data (underscore prevents matching 02_DatabaseConfiguration)
+    'Types',            # Matches 07_Types
+    'XmlSchemaCollections', # Matches 08_XmlSchemaCollections
+    'Defaults',         # Matches 12_Defaults
+    'Rules',            # Matches 13_Rules
+    'Data'              # Matches 21_Data
   )
 
   # Extract folder name from path (immediate parent)
   $parentFolder = Split-Path (Split-Path $ScriptPath -Parent) -Leaf
 
   # Check if this is a schema-bound folder
-  # Use partial matching since folders have numeric prefixes (e.g., 09_Tables_PrimaryKey)
+  # Strip numeric prefix (e.g., '09_Tables_PrimaryKey' -> 'Tables_PrimaryKey')
+  # then check for exact match or underscore-separated suffix (e.g., Tables, Tables_PrimaryKey)
+  $folderBase = $parentFolder -replace '^\d+_', ''
   $isSchemaBoundFolder = $false
   foreach ($folder in $schemaBoundFolders) {
-    if ($parentFolder -match $folder) {
+    if ($folderBase -eq $folder -or $folderBase -like "${folder}_*") {
       $isSchemaBoundFolder = $true
       break
     }
@@ -128,15 +134,18 @@ function Test-ObjectExcluded {
   # Only apply object filtering to folders containing schema-bound objects
   $schemaBoundFolders = @(
     'Tables', 'Indexes', 'Views', 'Functions', 'StoredProcedures',
-    'Triggers', 'Synonyms', 'Sequences', '_Data'
+    'Triggers', 'Synonyms', 'Sequences', 'Types', 'XmlSchemaCollections',
+    'Defaults', 'Rules', 'Data'
   )
 
   # Extract immediate parent folder name
   $parentFolder = Split-Path (Split-Path $ScriptPath -Parent) -Leaf
 
+  # Strip numeric prefix and check for exact match or underscore-separated suffix
+  $folderBase = $parentFolder -replace '^\d+_', ''
   $isSchemaBoundFolder = $false
   foreach ($folder in $schemaBoundFolders) {
-    if ($parentFolder -match $folder) {
+    if ($folderBase -eq $folder -or $folderBase -like "${folder}_*") {
       $isSchemaBoundFolder = $true
       break
     }

--- a/tests/test-schema-bound-folder-matching.ps1
+++ b/tests/test-schema-bound-folder-matching.ps1
@@ -1,0 +1,180 @@
+#Requires -Version 7.0
+
+<#
+.SYNOPSIS
+    Tests that schema-bound folder matching uses prefix matching, not substring matching.
+
+.DESCRIPTION
+    Regression tests for issue #112: Test-SchemaExcluded and Test-ObjectExcluded used
+    -match (regex substring matching) which caused false positives — e.g.,
+    'DatabaseConfiguration' matched 'Data'. The fix strips numeric prefixes and uses
+    -like with a trailing wildcard for safe substring-start matching.
+#>
+
+$ErrorActionPreference = 'Stop'
+Set-Location $PSScriptRoot
+
+# Test counters
+$script:TestsPassed = 0
+$script:TestsFailed = 0
+$script:TestsRun = 0
+
+function Write-TestResult {
+  param([string]$Name, [bool]$Passed, [string]$Details = '')
+  $script:TestsRun++
+  if ($Passed) {
+    $script:TestsPassed++
+    Write-Host "  [PASS] $Name" -ForegroundColor Green
+  } else {
+    $script:TestsFailed++
+    Write-Host "  [FAIL] $Name" -ForegroundColor Red
+    if ($Details) { Write-Host "         $Details" -ForegroundColor Yellow }
+  }
+}
+
+Write-Host "`n========================================" -ForegroundColor Cyan
+Write-Host "Schema-Bound Folder Matching Test (#112)" -ForegroundColor Cyan
+Write-Host "========================================`n" -ForegroundColor Cyan
+
+# ── Load import filter helpers ──
+$importHelpers = Join-Path $PSScriptRoot '..' 'Import-Helpers.ps1'
+if (-not (Test-Path $importHelpers)) {
+  Write-Host "[ERROR] Import-Helpers.ps1 not found at $importHelpers" -ForegroundColor Red
+  exit 1
+}
+. $importHelpers
+
+# Create temp directory structure
+$tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) "FolderMatchTest_$(Get-Random)"
+
+# Folders WITH numeric prefixes (realistic layout)
+$dirs = @(
+  (Join-Path $tempRoot '09_Tables'),
+  (Join-Path $tempRoot '09_Tables_PrimaryKey'),
+  (Join-Path $tempRoot '11_Tables_ForeignKeys'),
+  (Join-Path $tempRoot '10_Indexes'),
+  (Join-Path $tempRoot '05_Views'),
+  (Join-Path $tempRoot '02_Functions'),
+  (Join-Path $tempRoot '03_StoredProcedures'),
+  (Join-Path $tempRoot '04_Triggers'),
+  (Join-Path $tempRoot '15_Synonyms'),
+  (Join-Path $tempRoot '04_Sequences'),
+  (Join-Path $tempRoot '07_Types'),
+  (Join-Path $tempRoot '08_XmlSchemaCollections'),
+  (Join-Path $tempRoot '12_Defaults'),
+  (Join-Path $tempRoot '13_Rules'),
+  (Join-Path $tempRoot '21_Data'),
+  # Non-schema-bound folders
+  (Join-Path $tempRoot '02_DatabaseConfiguration'),
+  (Join-Path $tempRoot '01_Security'),
+  (Join-Path $tempRoot '03_Schemas'),
+  # False-positive traps
+  (Join-Path $tempRoot 'ExternalData'),
+  (Join-Path $tempRoot 'DataWarehouse')
+)
+
+foreach ($d in $dirs) {
+  New-Item -ItemType Directory -Path $d -Force | Out-Null
+}
+
+# Create mock SQL files in each directory
+foreach ($d in $dirs) {
+  'SELECT 1;' | Out-File -FilePath (Join-Path $d 'dbo.TestObj.sql') -Encoding utf8
+}
+
+try {
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 1: Test-SchemaExcluded — schema-bound folders match correctly
+  # ═══════════════════════════════════════════════════════════════
+  Write-Host "[PHASE 1] Test-SchemaExcluded: schema-bound folders match correctly" -ForegroundColor Yellow
+
+  $schemaBoundDirs = @(
+    '09_Tables', '09_Tables_PrimaryKey', '11_Tables_ForeignKeys',
+    '10_Indexes', '05_Views', '02_Functions', '03_StoredProcedures',
+    '04_Triggers', '15_Synonyms', '04_Sequences',
+    '07_Types', '08_XmlSchemaCollections', '12_Defaults', '13_Rules',
+    '21_Data'
+  )
+
+  foreach ($dir in $schemaBoundDirs) {
+    $path = Join-Path $tempRoot $dir 'dbo.TestObj.sql'
+    $result = Test-SchemaExcluded -ScriptPath $path -ExcludeSchemas @('dbo')
+    Write-TestResult -Name "SchemaExcluded: $dir recognized as schema-bound" -Passed ($result -eq $true)
+  }
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 2: Test-SchemaExcluded — non-schema-bound folders do NOT match
+  # ═══════════════════════════════════════════════════════════════
+  Write-Host "`n[PHASE 2] Test-SchemaExcluded: non-schema-bound folders do NOT match" -ForegroundColor Yellow
+
+  $nonSchemaBoundDirs = @(
+    '02_DatabaseConfiguration', '01_Security', '03_Schemas'
+  )
+
+  foreach ($dir in $nonSchemaBoundDirs) {
+    $path = Join-Path $tempRoot $dir 'dbo.TestObj.sql'
+    $result = Test-SchemaExcluded -ScriptPath $path -ExcludeSchemas @('dbo')
+    Write-TestResult -Name "SchemaExcluded: $dir NOT schema-bound" -Passed ($result -eq $false)
+  }
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 3: False positive regression — substring must NOT match
+  # ═══════════════════════════════════════════════════════════════
+  Write-Host "`n[PHASE 3] False positive regression tests" -ForegroundColor Yellow
+
+  # DatabaseConfiguration should NOT match 'Data'
+  $path = Join-Path $tempRoot '02_DatabaseConfiguration' 'dbo.TestObj.sql'
+  $result = Test-SchemaExcluded -ScriptPath $path -ExcludeSchemas @('dbo')
+  Write-TestResult -Name "False positive: DatabaseConfiguration does NOT match Data" -Passed ($result -eq $false)
+
+  # ExternalData should NOT match 'Data' (no numeric prefix)
+  $path = Join-Path $tempRoot 'ExternalData' 'dbo.TestObj.sql'
+  $result = Test-SchemaExcluded -ScriptPath $path -ExcludeSchemas @('dbo')
+  Write-TestResult -Name "False positive: ExternalData does NOT match Data" -Passed ($result -eq $false)
+
+  # DataWarehouse should NOT match 'Data' (no numeric prefix)
+  $path = Join-Path $tempRoot 'DataWarehouse' 'dbo.TestObj.sql'
+  $result = Test-SchemaExcluded -ScriptPath $path -ExcludeSchemas @('dbo')
+  Write-TestResult -Name "False positive: DataWarehouse does NOT match Data" -Passed ($result -eq $false)
+
+  # ═══════════════════════════════════════════════════════════════
+  # PHASE 4: Test-ObjectExcluded — same folder matching logic
+  # ═══════════════════════════════════════════════════════════════
+  Write-Host "`n[PHASE 4] Test-ObjectExcluded: folder matching logic" -ForegroundColor Yellow
+
+  # Schema-bound folders should be recognized
+  foreach ($dir in @('09_Tables', '07_Types', '08_XmlSchemaCollections', '12_Defaults', '13_Rules', '21_Data')) {
+    $path = Join-Path $tempRoot $dir 'dbo.TestObj.sql'
+    $result = Test-ObjectExcluded -ScriptPath $path -ExcludeObjects @('dbo.TestObj')
+    Write-TestResult -Name "ObjectExcluded: $dir recognized as schema-bound" -Passed ($result -eq $true)
+  }
+
+  # Non-schema-bound folders should NOT filter
+  $path = Join-Path $tempRoot '02_DatabaseConfiguration' 'dbo.TestObj.sql'
+  $result = Test-ObjectExcluded -ScriptPath $path -ExcludeObjects @('dbo.TestObj')
+  Write-TestResult -Name "ObjectExcluded: DatabaseConfiguration NOT schema-bound" -Passed ($result -eq $false)
+
+  # False positive: ExternalData should NOT match Data
+  $path = Join-Path $tempRoot 'ExternalData' 'dbo.TestObj.sql'
+  $result = Test-ObjectExcluded -ScriptPath $path -ExcludeObjects @('dbo.TestObj')
+  Write-TestResult -Name "ObjectExcluded: ExternalData does NOT match Data" -Passed ($result -eq $false)
+
+} finally {
+  # Cleanup temp directory
+  if (Test-Path $tempRoot) {
+    Remove-Item $tempRoot -Recurse -Force
+  }
+}
+
+# Summary
+Write-Host "`n========================================" -ForegroundColor Cyan
+Write-Host "Test Summary: $script:TestsPassed/$script:TestsRun passed" -ForegroundColor Cyan
+Write-Host "========================================`n" -ForegroundColor Cyan
+
+if ($script:TestsFailed -gt 0) {
+  Write-Host "[FAILED] $script:TestsFailed test(s) failed" -ForegroundColor Red
+  exit 1
+} else {
+  Write-Host "[SUCCESS] All tests passed!" -ForegroundColor Green
+  exit 0
+}


### PR DESCRIPTION
## Summary

- Replace `-match` (regex substring matching) with prefix-stripping and exact/underscore-boundary checks (`-eq` / `-like "${folder}_*"`) in `Test-SchemaExcluded` and `Test-ObjectExcluded`
- Fixes false positives where folders like `DatabaseConfiguration` incorrectly matched the `Data` entry
- Add missing schema-bound folders: `Types`, `XmlSchemaCollections`, `Defaults`, `Rules`
- Revert `_Data` workaround back to `Data` (no longer needed with correct matching)

Closes #112

## Test plan

- [x] New regression tests pass (29/29): `tests/test-schema-bound-folder-matching.ps1`
- [x] Existing tests pass (32/32): `tests/test-exclude-objects-import.ps1`
- [ ] Verify in CI