### PR TITLE
docs: document Import -ExcludeObjects matching behavior

### DIFF
--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -233,7 +233,7 @@ param(
   [Parameter(HelpMessage = 'Exclude specific schemas from import. Example: cdc,staging')]
   [string[]]$ExcludeSchemas,
 
-  [Parameter(HelpMessage = 'Exclude objects by filename pattern using schema.name format (wildcards supported, full name match). Example: dbo.usp_LegacyProc,staging.*')]
+  [Parameter(HelpMessage = 'Exclude objects by matching schema.objectName from script filenames (case-insensitive wildcards, full name match). Example: dbo.usp_LegacyProc,staging.*')]
   [string[]]$ExcludeObjects,
 
   [Parameter(HelpMessage = 'Strip FILESTREAM features (removes FILESTREAM_ON clauses, converts FILESTREAM columns to VARBINARY(MAX)). Required for Linux/container targets.')]

--- a/Import-SqlServerSchema.ps1
+++ b/Import-SqlServerSchema.ps1
@@ -233,7 +233,7 @@ param(
   [Parameter(HelpMessage = 'Exclude specific schemas from import. Example: cdc,staging')]
   [string[]]$ExcludeSchemas,
 
-  [Parameter(HelpMessage = 'Exclude specific objects from import using schema.name pattern (supports wildcards). Example: dbo.usp_LegacyProc,staging.*')]
+  [Parameter(HelpMessage = 'Exclude objects by filename pattern using schema.name format (wildcards supported, full name match). Example: dbo.usp_LegacyProc,staging.*')]
   [string[]]$ExcludeObjects,
 
   [Parameter(HelpMessage = 'Strip FILESTREAM features (removes FILESTREAM_ON clauses, converts FILESTREAM columns to VARBINARY(MAX)). Required for Linux/container targets.')]

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ DbScripts/
 | `-IncludeObjectTypes` | No | Whitelist: Only import specified types (e.g., Schemas,Tables,Views) |
 | `-ExcludeObjectTypes` | No | Blacklist: Import all except specified types (e.g., WindowsUsers) |
 | `-ExcludeSchemas` | No | Exclude scripts by schema prefix (e.g., cdc,staging) |
+| `-ExcludeObjects` | No | Exclude specific objects by filename pattern (e.g., dbo.usp_Legacy*) |
 | `-Credential` | No | SQL authentication credentials |
 | `-ServerFromEnv` | No | Env var name for server address (e.g., SQLCMD_SERVER) |
 | `-UsernameFromEnv` | No | Env var name for username (e.g., SQLCMD_USER) |
@@ -665,6 +666,29 @@ Both Export and Import scripts support filtering which object types to process v
 ```
 
 **Why `-Force`?** The Import script checks if the database already contains objects and stops to prevent accidental overwrites. When doing selective imports to an existing database, use `-Force` to bypass this check.
+
+**Object exclusion** (`-ExcludeObjects`): Exclude individual objects by `schema.objectName` filename pattern
+```powershell
+# Exclude a specific stored procedure
+./Import-SqlServerSchema.ps1 -Server localhost -Database MyDb -SourcePath ./DbScripts/... `
+    -ExcludeObjects "dbo.usp_LegacyReport"
+
+# Exclude multiple stored procedures with overlapping names
+# "dbo.usp_Process" does NOT match "dbo.usp_ProcessOrders" — full name match required
+./Import-SqlServerSchema.ps1 -Server localhost -Database MyDb -SourcePath ./DbScripts/... `
+    -ExcludeObjects "dbo.usp_Process","dbo.usp_ProcessOrders"
+
+# Wildcard: exclude all stored procedures starting with usp_Legacy
+# Matches dbo.usp_LegacyReport, dbo.usp_LegacyImport, etc.
+./Import-SqlServerSchema.ps1 -Server localhost -Database MyDb -SourcePath ./DbScripts/... `
+    -ExcludeObjects "dbo.usp_Legacy*"
+
+# Exclude all objects in the staging schema
+./Import-SqlServerSchema.ps1 -Server localhost -Database MyDb -SourcePath ./DbScripts/... `
+    -ExcludeObjects "staging.*"
+```
+
+> **Note:** `-ExcludeObjects` matches against `schema.objectName` extracted from filenames (not SQL object names). It uses PowerShell `-ilike` for full string matching — `dbo.usp_Process` will **not** match `dbo.usp_ProcessOrders`. Only applies to schema-bound folders (Tables, Views, Functions, StoredProcedures, etc.) when using single grouping mode. See [#118](https://github.com/AgileSqlClub/Export-SqlServerSchema/issues/118) for known limitations.
 
 ### Multi-Pass Import with -Force Flag
 

--- a/README.md
+++ b/README.md
@@ -688,7 +688,7 @@ Both Export and Import scripts support filtering which object types to process v
     -ExcludeObjects "staging.*"
 ```
 
-> **Note:** `-ExcludeObjects` matches against `schema.objectName` extracted from filenames (not SQL object names). It uses PowerShell `-ilike` for full string matching — `dbo.usp_Process` will **not** match `dbo.usp_ProcessOrders`. Only applies to schema-bound folders (Tables, Views, Functions, StoredProcedures, etc.) when using single grouping mode. See [#118](https://github.com/AgileSqlClub/Export-SqlServerSchema/issues/118) for known limitations.
+> **Note:** `-ExcludeObjects` matches against `schema.objectName` extracted from filenames (not SQL object names) using PowerShell `-ilike` for full-string matching — `dbo.usp_Process` will **not** match `dbo.usp_ProcessOrders`. Only reliable for excluding individual objects when the corresponding object type was exported in **single** grouping mode. In schema or all modes, objects are combined into grouped files so patterns may not match as expected. See [#118](https://github.com/AgileSqlClub/Export-SqlServerSchema/issues/118) for known limitations.
 
 ### Multi-Pass Import with -Force Flag
 

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -661,6 +661,34 @@ import:
     - temp
 ```
 
+#### `import.excludeObjects`
+
+- **Type**: Array of strings (patterns)
+- **Default**: Empty
+- **Description**: Exclude specific objects from import by matching `schema.objectName` extracted from filenames
+- **Matching**: Uses PowerShell `-ilike` (case-insensitive, **full string match** — not substring)
+- **Wildcards**: `*` matches any characters (including none), `?` matches exactly one character
+- **Pattern format**: `schema.objectName` (do NOT use SQL bracket notation like `[dbo].[name]`)
+- **Scope**: Only applies to schema-bound object folders (Tables, Views, Functions, StoredProcedures, Indexes, Triggers, Synonyms, Sequences, Types, XmlSchemaCollections, Defaults, Rules, Data)
+- **Limitation**: Only works with single grouping mode; patterns silently have no effect in schema or all modes. See [#118](https://github.com/AgileSqlClub/Export-SqlServerSchema/issues/118) for details.
+
+**Matching behavior with overlapping names:**
+
+| Pattern | `dbo.usp_Process` | `dbo.usp_ProcessOrders` | `dbo.usp_ProcessReturns` |
+|---|---|---|---|
+| `dbo.usp_Process` | matches | no | no |
+| `dbo.usp_Process*` | matches | matches | matches |
+| `dbo.usp_Process?rders` | no | no | no |
+| `dbo.usp_ProcessOrders` | no | matches | no |
+
+```yaml
+import:
+  excludeObjects:
+    - "dbo.usp_LegacyProc"     # Exact match — does NOT match dbo.usp_LegacyProcV2
+    - "staging.*"               # All objects in the staging schema
+    - "dbo.usp_Legacy*"        # All objects starting with dbo.usp_Legacy
+```
+
 #### `import.dependencyRetries`
 
 Settings for handling cross-object dependencies in programmability objects.

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -670,7 +670,7 @@ import:
 - **Wildcards**: `*` matches any characters (including none), `?` matches exactly one character
 - **Pattern format**: `schema.objectName` (do NOT use SQL bracket notation like `[dbo].[name]`)
 - **Scope**: Only applies to schema-bound object folders (Tables, Views, Functions, StoredProcedures, Indexes, Triggers, Synonyms, Sequences, Types, XmlSchemaCollections, Defaults, Rules, Data)
-- **Limitation**: Only works with single grouping mode; patterns silently have no effect in schema or all modes. See [#118](https://github.com/AgileSqlClub/Export-SqlServerSchema/issues/118) for details.
+- **Limitation**: Only supported with single grouping mode; in schema or all modes patterns do not reliably match individual objects and should not be relied on. See [#118](https://github.com/AgileSqlClub/Export-SqlServerSchema/issues/118) for details.
 
 **Matching behavior with overlapping names:**
 
@@ -678,7 +678,7 @@ import:
 |---|---|---|---|
 | `dbo.usp_Process` | matches | no | no |
 | `dbo.usp_Process*` | matches | matches | matches |
-| `dbo.usp_Process?rders` | no | no | no |
+| `dbo.usp_Process?rders` | no | matches | no |
 | `dbo.usp_ProcessOrders` | no | matches | no |
 
 ```yaml

--- a/export-import-config.example.yml
+++ b/export-import-config.example.yml
@@ -249,7 +249,8 @@ import:
     # - temp
 
   # Exclude specific objects by filename pattern (schema.objectName, full match, wildcards supported)
-  # Only applies to schema-bound folders (Tables, Views, Functions, etc.) in single grouping mode
+  # Only reliably excludes individual objects when the relevant object type is exported in single mode.
+  # Not supported for grouped files (grouped filenames may not match patterns as expected).
   # Note: "dbo.usp_Process" does NOT match "dbo.usp_ProcessOrders" — use "dbo.usp_Process*" for prefix matching
   # excludeObjects: []
     # - "dbo.usp_LegacyProc"           # Exact match only (not dbo.usp_LegacyProcV2)

--- a/export-import-config.example.yml
+++ b/export-import-config.example.yml
@@ -243,6 +243,19 @@ import:
   # Object types to include in import (if specified, only these types are imported)
   # includeObjectTypes: []
 
+  # Schemas to exclude from import (only applies to schema-bound object folders)
+  # excludeSchemas: []
+    # - staging
+    # - temp
+
+  # Exclude specific objects by filename pattern (schema.objectName, full match, wildcards supported)
+  # Only applies to schema-bound folders (Tables, Views, Functions, etc.) in single grouping mode
+  # Note: "dbo.usp_Process" does NOT match "dbo.usp_ProcessOrders" — use "dbo.usp_Process*" for prefix matching
+  # excludeObjects: []
+    # - "dbo.usp_LegacyProc"           # Exact match only (not dbo.usp_LegacyProcV2)
+    # - "staging.*"                     # Exclude all staging schema objects
+    # - "dbo.usp_Legacy*"              # Exclude all objects starting with dbo.usp_Legacy
+
   # ─────────────────────────────────────────────────────────────
   # DEPENDENCY RETRY SETTINGS
   # ─────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Closes #119

- Add `-ExcludeObjects` to README parameter table with usage examples showing overlapping name behavior
- Rewrite `import.excludeObjects` in CONFIG_REFERENCE.md with precise matching semantics and a pattern/match table
- Update example YAML comments to clarify filename-based full matching
- Update HelpMessage in Import-SqlServerSchema.ps1

## Key points documented

- Matches `schema.objectName` extracted from **filenames**, not SQL object names
- Uses `-ilike` full string match — `dbo.usp_Process` does NOT match `dbo.usp_ProcessOrders`
- Only applies to schema-bound folders in single grouping mode
- Links to #118 for known limitations

## Test plan

- [x] Existing tests pass: `tests/test-exclude-objects-import.ps1` (32/32)
- [ ] Review docs read naturally and accurately describe behavior