### PR TITLE
fix: add missing Import-Helpers.ps1 and ConvertTo-ImportReport.ps1 to release workflow

### DIFF
--- a/.github/workflows/ci-main.yml
+++ b/.github/workflows/ci-main.yml
@@ -136,7 +136,9 @@ jobs:
           cp export-import-config.example.yml release/
           cp export-import-config.schema.json release/
           cp Common-SqlServerSchema.ps1 release/
+          cp ConvertTo-ImportReport.ps1 release/
           cp Export-SqlServerSchema.ps1 release/
+          cp Import-Helpers.ps1 release/
           cp Import-SqlServerSchema.ps1 release/
           cp LICENSE.md release/
           cp README.md release/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to Export-SqlServerSchema will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.9.1] - 2026-03-04
+
+### Fixed
+
+- **Release workflow missing `Import-Helpers.ps1` and `ConvertTo-ImportReport.ps1`** — The `ci-main.yml` release job did not copy `Import-Helpers.ps1` or `ConvertTo-ImportReport.ps1` into the release archive. Both files are required at runtime: `Import-SqlServerSchema.ps1` dot-sources `Import-Helpers.ps1` and invokes `ConvertTo-ImportReport.ps1` for post-import summaries.
+
 ## [1.9.0] - 2026-03-04
 
 ### Changed


### PR DESCRIPTION
Fixes #125

## Changes

- Added \Import-Helpers.ps1\ and \ConvertTo-ImportReport.ps1\ to the release file copy step in \ci-main.yml\
- Added changelog entry for v1.9.1

## Context

The release job in \ci-main.yml\ was missing two files that \Import-SqlServerSchema.ps1\ requires at runtime:
- \Import-Helpers.ps1\ — dot-sourced for filter functions
- \ConvertTo-ImportReport.ps1\ — invoked for post-import summary rendering